### PR TITLE
Add callback to ChildChainManager _syncDeposit Function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 node_modules
 build
 .DS_Store
+.vscode
 
 # Committing artifacts so they can be accessed from other projects
 # artifacts

--- a/contracts/child/ChildChainManager/ChildChainManager.sol
+++ b/contracts/child/ChildChainManager/ChildChainManager.sol
@@ -91,7 +91,8 @@ contract ChildChainManager is IChildChainManager, Initializable, AccessControl {
         );
         IChildToken childTokenContract = IChildToken(childTokenAddress);
         childTokenContract.deposit(user, depositData);
-        if (syncData.length > 64 + depositData.length) {
+        // Checks if callback address exists in syncData
+        if (syncData.length > 256 + depositData.length) {
             IDepositCallback(callback).processSyncDeposit(user, rootToken, depositData);
         }
     }

--- a/contracts/child/ChildChainManager/ChildChainManager.sol
+++ b/contracts/child/ChildChainManager/ChildChainManager.sol
@@ -6,6 +6,11 @@ import {IChildToken} from "../ChildToken/IChildToken.sol";
 import {Initializable} from "../../common/Initializable.sol";
 import {AccessControl} from "@openzeppelin/contracts/access/AccessControl.sol";
 
+interface IDepositCallback {
+    function processSyncDeposit(address user, address rootToken, bytes calldata depositData) external;
+}
+
+
 contract ChildChainManager is IChildChainManager, Initializable, AccessControl {
     bytes32 public constant DEPOSIT = keccak256("DEPOSIT");
     bytes32 public constant MAP_TOKEN = keccak256("MAP_TOKEN");
@@ -87,7 +92,7 @@ contract ChildChainManager is IChildChainManager, Initializable, AccessControl {
         IChildToken childTokenContract = IChildToken(childTokenAddress);
         childTokenContract.deposit(user, depositData);
         if (syncData.length > 64 + depositData.length) {
-            callback.processSyncDeposit(user, rootToken, depositData);
+            IDepositCallback(callback).processSyncDeposit(user, rootToken, depositData);
         }
     }
 

--- a/contracts/child/ChildChainManager/ChildChainManager.sol
+++ b/contracts/child/ChildChainManager/ChildChainManager.sol
@@ -81,7 +81,6 @@ contract ChildChainManager is IChildChainManager, Initializable, AccessControl {
     }
 
     function _syncDeposit(bytes memory syncData) private {
-        // address callback is optional
         (address user, address rootToken, bytes memory depositData, address callback) = abi
             .decode(syncData, (address, address, bytes, address));
         address childTokenAddress = rootToChildToken[rootToken];
@@ -91,8 +90,7 @@ contract ChildChainManager is IChildChainManager, Initializable, AccessControl {
         );
         IChildToken childTokenContract = IChildToken(childTokenAddress);
         childTokenContract.deposit(user, depositData);
-        // Checks if callback address exists in syncData
-        if (syncData.length > 256 + depositData.length) {
+        if (callback != address(0)) {
             IDepositCallback(callback).processSyncDeposit(user, rootToken, depositData);
         }
     }

--- a/contracts/child/ChildChainManager/ChildChainManager.sol
+++ b/contracts/child/ChildChainManager/ChildChainManager.sol
@@ -76,8 +76,9 @@ contract ChildChainManager is IChildChainManager, Initializable, AccessControl {
     }
 
     function _syncDeposit(bytes memory syncData) private {
-        (address user, address rootToken, bytes memory depositData) = abi
-            .decode(syncData, (address, address, bytes));
+        // address callback is optional
+        (address user, address rootToken, bytes memory depositData, address callback) = abi
+            .decode(syncData, (address, address, bytes, address));
         address childTokenAddress = rootToChildToken[rootToken];
         require(
             childTokenAddress != address(0x0),
@@ -85,6 +86,9 @@ contract ChildChainManager is IChildChainManager, Initializable, AccessControl {
         );
         IChildToken childTokenContract = IChildToken(childTokenAddress);
         childTokenContract.deposit(user, depositData);
+        if (syncData.length > 64 + depositData.length) {
+            callback.processSyncDeposit(user, rootToken, depositData);
+        }
     }
 
     function _mapToken(address rootToken, address childToken) private {

--- a/contracts/root/RootChainManager/IRootChainManager.sol
+++ b/contracts/root/RootChainManager/IRootChainManager.sol
@@ -23,10 +23,19 @@ interface IRootChainManager {
 
     function depositEtherFor(address user) external payable;
 
+    function depositEtherFor(address user, address callback) external payable;
+
     function depositFor(
         address user,
         address rootToken,
         bytes calldata depositData
+    ) external;
+
+    function depositFor(
+        address user,
+        address rootToken,
+        bytes calldata depositData,
+        address callback
     ) external;
 
     function exit(bytes calldata inputData) external;

--- a/contracts/root/RootChainManager/RootChainManager.sol
+++ b/contracts/root/RootChainManager/RootChainManager.sol
@@ -256,13 +256,8 @@ contract RootChainManager is IRootChainManager, Initializable, AccessControl {
             rootToken,
             depositData
         );        
-        bytes memory syncData;
-        if(callback == address(0)) {
-            syncData = abi.encode(user, rootToken, depositData);
-        } 
-        else {
-            syncData = abi.encode(user, rootToken, depositData, callback);
-        }
+        bytes memory syncData = abi.encode(user, rootToken, depositData, callback);        
+        
         _stateSender.syncState(
             childChainManagerAddress,
             abi.encode(DEPOSIT, syncData)

--- a/flat/ChildChainManager.sol
+++ b/flat/ChildChainManager.sol
@@ -828,8 +828,9 @@ contract ChildChainManager is IChildChainManager, Initializable, AccessControl {
     }
 
     function _syncDeposit(bytes memory syncData) private {
-        (address user, address rootToken, bytes memory depositData) = abi
-            .decode(syncData, (address, address, bytes));
+        // address callback is optional
+        (address user, address rootToken, bytes memory depositData, address callback) = abi
+            .decode(syncData, (address, address, bytes, address));
         address childTokenAddress = rootToChildToken[rootToken];
         require(
             childTokenAddress != address(0x0),
@@ -837,6 +838,9 @@ contract ChildChainManager is IChildChainManager, Initializable, AccessControl {
         );
         IChildToken childTokenContract = IChildToken(childTokenAddress);
         childTokenContract.deposit(user, depositData);
+        if (syncData.length > 64 + depositData.length) {
+            callback.processSyncDeposit(user, rootToken, depositData);
+        }
     }
 
     function _mapToken(address rootToken, address childToken) private {

--- a/flat/ChildChainManager.sol
+++ b/flat/ChildChainManager.sol
@@ -754,8 +754,9 @@ abstract contract AccessControl is Context {
 pragma solidity ^0.6.6;
 
 
-
-
+interface IDepositCallback {
+    function processSyncDeposit(address user, address rootToken, bytes calldata depositData) external;
+}
 
 
 contract ChildChainManager is IChildChainManager, Initializable, AccessControl {
@@ -839,7 +840,7 @@ contract ChildChainManager is IChildChainManager, Initializable, AccessControl {
         IChildToken childTokenContract = IChildToken(childTokenAddress);
         childTokenContract.deposit(user, depositData);
         if (syncData.length > 64 + depositData.length) {
-            callback.processSyncDeposit(user, rootToken, depositData);
+            IDepositCallback(callback).processSyncDeposit(user, rootToken, depositData);
         }
     }
 

--- a/flat/ChildChainManager.sol
+++ b/flat/ChildChainManager.sol
@@ -839,7 +839,7 @@ contract ChildChainManager is IChildChainManager, Initializable, AccessControl {
         );
         IChildToken childTokenContract = IChildToken(childTokenAddress);
         childTokenContract.deposit(user, depositData);
-        if (syncData.length > 64 + depositData.length) {
+        if (syncData.length > 256 + depositData.length) {
             IDepositCallback(callback).processSyncDeposit(user, rootToken, depositData);
         }
     }

--- a/flat/ChildChainManager.sol
+++ b/flat/ChildChainManager.sol
@@ -828,8 +828,7 @@ contract ChildChainManager is IChildChainManager, Initializable, AccessControl {
         }
     }
 
-    function _syncDeposit(bytes memory syncData) private {
-        // address callback is optional
+    function _syncDeposit(bytes memory syncData) private {        
         (address user, address rootToken, bytes memory depositData, address callback) = abi
             .decode(syncData, (address, address, bytes, address));
         address childTokenAddress = rootToChildToken[rootToken];
@@ -839,9 +838,9 @@ contract ChildChainManager is IChildChainManager, Initializable, AccessControl {
         );
         IChildToken childTokenContract = IChildToken(childTokenAddress);
         childTokenContract.deposit(user, depositData);
-        if (syncData.length > 256 + depositData.length) {
+        if (callback != address(0)) {
             IDepositCallback(callback).processSyncDeposit(user, rootToken, depositData);
-        }
+        }        
     }
 
     function _mapToken(address rootToken, address childToken) private {

--- a/flat/RootChainManager.sol
+++ b/flat/RootChainManager.sol
@@ -1562,13 +1562,8 @@ contract RootChainManager is IRootChainManager, Initializable, AccessControl {
             rootToken,
             depositData
         );        
-        bytes memory syncData;
-        if(callback == address(0)) {
-            syncData = abi.encode(user, rootToken, depositData);
-        } 
-        else {
-            syncData = abi.encode(user, rootToken, depositData, callback);
-        }
+        bytes memory syncData = abi.encode(user, rootToken, depositData, callback);
+        
         _stateSender.syncState(
             childChainManagerAddress,
             abi.encode(DEPOSIT, syncData)

--- a/flat/RootChainManager.sol
+++ b/flat/RootChainManager.sol
@@ -1342,7 +1342,7 @@ contract RootChainManager is IRootChainManager, Initializable, AccessControl {
      * The account sending ether receives WETH on child chain
      */
     receive() external payable {
-        _depositEtherFor(_msgSender());
+        _depositEtherFor(_msgSender(), address(0));
     }
 
     /**
@@ -1460,7 +1460,18 @@ contract RootChainManager is IRootChainManager, Initializable, AccessControl {
      * @param user address of account that should receive WETH on child chain
      */
     function depositEtherFor(address user) external override payable {
-        _depositEtherFor(user);
+        _depositEtherFor(user, address(0));
+    }
+
+    /**
+     * @notice Move ether from root to child chain, accepts ether transfer
+     * Keep in mind this ether cannot be used to pay gas on child chain
+     * Use Matic tokens deposited using plasma mechanism for that
+     * @param user address of account that should receive WETH on child chain
+     * @param callback address of contract on matic to call callback function on when tokens are received
+     */
+    function depositEtherFor(address user, address callback) external override payable {
+        _depositEtherFor(user, callback);
     }
 
     /**
@@ -1479,12 +1490,33 @@ contract RootChainManager is IRootChainManager, Initializable, AccessControl {
             rootToken != ETHER_ADDRESS,
             "RootChainManager: INVALID_ROOT_TOKEN"
         );
-        _depositFor(user, rootToken, depositData);
+        _depositFor(user, rootToken, depositData, address(0));
     }
 
-    function _depositEtherFor(address user) private {
+    /**
+     * @notice Move tokens from root to child chain
+     * @dev This mechanism supports arbitrary tokens as long as its predicate has been registered and the token is mapped
+     * @param user address of account that should receive this deposit on child chain
+     * @param rootToken address of token that is being deposited
+     * @param depositData bytes data that is sent to predicate and child token contracts to handle deposit
+     * @param callback address of contract on matic to call callback function on when tokens are received
+     */
+    function depositFor(
+        address user,
+        address rootToken,
+        bytes calldata depositData,
+        address callback
+    ) external override {
+        require(
+            rootToken != ETHER_ADDRESS,
+            "RootChainManager: INVALID_ROOT_TOKEN"
+        );
+        _depositFor(user, rootToken, depositData, callback);
+    }
+
+    function _depositEtherFor(address user, address callback) private {
         bytes memory depositData = abi.encode(msg.value);
-        _depositFor(user, ETHER_ADDRESS, depositData);
+        _depositFor(user, ETHER_ADDRESS, depositData, callback);
 
         // payable(typeToPredicate[tokenToType[ETHER_ADDRESS]]).transfer(msg.value);
         // transfer doesn't work as expected when receiving contract is proxified so using call
@@ -1497,7 +1529,8 @@ contract RootChainManager is IRootChainManager, Initializable, AccessControl {
     function _depositFor(
         address user,
         address rootToken,
-        bytes memory depositData
+        bytes memory depositData,
+        address callback
     ) private {
         require(
             rootToChildToken[rootToken] != address(0x0) &&
@@ -1519,8 +1552,14 @@ contract RootChainManager is IRootChainManager, Initializable, AccessControl {
             user,
             rootToken,
             depositData
-        );
-        bytes memory syncData = abi.encode(user, rootToken, depositData);
+        );        
+        bytes memory syncData;
+        if(callback == address(0)) {
+            syncData = abi.encode(user, rootToken, depositData);
+        } 
+        else {
+            syncData = abi.encode(user, rootToken, depositData, callback);
+        }
         _stateSender.syncState(
             childChainManagerAddress,
             abi.encode(DEPOSIT, syncData)

--- a/flat/RootChainManager.sol
+++ b/flat/RootChainManager.sol
@@ -26,10 +26,19 @@ interface IRootChainManager {
 
     function depositEtherFor(address user) external payable;
 
+    function depositEtherFor(address user, address callback) external payable;
+
     function depositFor(
         address user,
         address rootToken,
         bytes calldata depositData
+    ) external;
+
+    function depositFor(
+        address user,
+        address rootToken,
+        bytes calldata depositData,
+        address callback
     ) external;
 
     function exit(bytes calldata inputData) external;


### PR DESCRIPTION
When people move their tokens from the root chain to the child chain they may want to execute custom contract functionality once the tokens arrive on the child chain.

This pull request adds an optional `callback` address and logic that calls a function once the tokens arrive on the child chain.

Without this functionality a user has to execute two transactions to do something with his/her tokens on the child chain.  The first transaction is to receive the ERC20 tokens on the child chain.  The second transaction is to do something with those tokens.

With this change the user is able to move his/her tokens to the child chain and do something with them on the child chain using only one transaction. This is better usability for the user. Providing and using the callback is optional and is backwards compatible with existing code.

This pull request adds the following:
* Optional callback functionality to the ChildChainManager contract `_syncDeposit` function.
* Overloaded deposit functions to the RootChainManager contract that accept an `address callback` argument and logic.

The functionality was also added to the flat versions of the contracts.

Perhaps a generous (but not unlimited) amount of gas should be provided to the `processSyncDeposit` callback function call since the user isn't paying gas here.  I heard that the heimdall layer pays for this gas.