### PR TITLE
Child DAI token

### DIFF
--- a/contracts/child/ChildToken/DappTokens/UChildDAI.sol
+++ b/contracts/child/ChildToken/DappTokens/UChildDAI.sol
@@ -1,0 +1,53 @@
+pragma solidity 0.6.6;
+
+import {UChildERC20} from "../UpgradeableChildERC20/UChildERC20.sol";
+
+contract UChildDAI is UChildERC20 {
+    // bytes32 public constant PERMIT_TYPEHASH = keccak256("Permit(address holder,address spender,uint256 nonce,uint256 expiry,bool allowed)");
+    bytes32 public constant PERMIT_TYPEHASH = 0xea2aa0a1be11a07ed86d755c93467f4f82362b452371d1ba94d1715123511acb;
+
+    // --- Alias ---
+    function push(address usr, uint wad) external {
+        transferFrom(msg.sender, usr, wad);
+    }
+    function pull(address usr, uint wad) external {
+        transferFrom(usr, msg.sender, wad);
+    }
+    function move(address src, address dst, uint wad) external {
+        transferFrom(src, dst, wad);
+    }
+
+    // --- Approve by signature ---
+    function permit(
+        address holder,
+        address spender,
+        uint256 nonce,
+        uint256 expiry,
+        bool allowed,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) external {
+        bytes32 digest = keccak256(
+            abi.encodePacked(
+                "\x19\x01",
+                getDomainSeperator(),
+                keccak256(
+                    abi.encode(
+                        PERMIT_TYPEHASH,
+                        holder,
+                        spender,
+                        nonce,
+                        expiry,
+                        allowed
+                    )
+                )
+        ));
+
+        require(holder == ecrecover(digest, v, r, s), "UChildDAI: INVALID-PERMIT");
+        require(expiry == 0 || now <= expiry, "UChildDAI: PERMIT-EXPIRED");
+        require(nonce == nonces[holder]++, "UChildDAI: INVALID-NONCE");
+        uint wad = allowed ? uint(-1) : 0;
+        _approve(holder, spender, wad);
+    }
+}

--- a/contracts/child/ChildToken/DappTokens/UChildDAI.sol
+++ b/contracts/child/ChildToken/DappTokens/UChildDAI.sol
@@ -47,6 +47,7 @@ contract UChildDAI is UChildERC20 {
         require(holder == ecrecover(digest, v, r, s), "UChildDAI: INVALID-PERMIT");
         require(expiry == 0 || now <= expiry, "UChildDAI: PERMIT-EXPIRED");
         require(nonce == nonces[holder]++, "UChildDAI: INVALID-NONCE");
+        require(msg.sender != address(this), "UChildDAI: PERMIT_META_TX_DISABLED");
         uint wad = allowed ? uint(-1) : 0;
         _approve(holder, spender, wad);
     }

--- a/test/child/UChildDAI.test.js
+++ b/test/child/UChildDAI.test.js
@@ -1,0 +1,151 @@
+import chai from 'chai'
+import chaiAsPromised from 'chai-as-promised'
+import chaiBN from 'chai-bn'
+import BN from 'bn.js'
+import * as sigUtils from 'eth-sig-util'
+import * as ethUtils from 'ethereumjs-util'
+
+import { generateFirstWallets, getSignatureParameters } from '../helpers/utils'
+import { mockValues } from '../helpers/constants'
+import contracts from '../helpers/contracts'
+
+chai
+  .use(chaiAsPromised)
+  .use(chaiBN(BN))
+  .should()
+
+const should = chai.should()
+const wallets = generateFirstWallets({ n: 10 })
+
+contract('UChildDAI', (accounts) => {
+  describe('Set approval using permit function', () => {
+    const cinnamon = 'Cinnamon'
+    const staranise = 'Star anise'
+    const symbol = 'CSC'
+    const decimals = 18
+    const childChainManager = mockValues.addresses[2]
+    const admin = accounts[0]
+    const jack = wallets[4].getAddressString()
+    const jackPK = ethUtils.toBuffer(wallets[4].getPrivateKeyString())
+    const jill = mockValues.addresses[6]
+    const maxAmount = new BN('ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff', 'hex')
+    const zeroAmount = new BN(0)
+    let uChildDAI
+
+    before(async() => {
+      uChildDAI = await contracts.UChildDAI.new({ from: admin })
+      await uChildDAI.initialize(cinnamon, symbol, decimals, childChainManager, { from: admin })
+      await uChildDAI.changeName(staranise, { from: admin })
+    })
+
+    it(`Admin should be able to permit jill to spend jack's tokens using offline signature`, async() => {
+      const name = await uChildDAI.name()
+      const chainId = await uChildDAI.getChainId()
+      const nonce = await uChildDAI.getNonce(jack)
+
+      const sig = sigUtils.signTypedData(jackPK, {
+        data: getTypedData({
+          name,
+          version: '1',
+          chainId,
+          verifyingContract: uChildDAI.address,
+          nonce: '0x' + nonce.toString(16),
+          holder: jack,
+          spender: jill,
+          allowed: true
+        })
+      })
+      const { r, s, v } = getSignatureParameters(sig)
+      const tx = await uChildDAI.permit(jack, jill, nonce, 0, true, v, r, s, { from: admin })
+      should.exist(tx)
+    })
+
+    it('Allowance should be max', async() => {
+      const allowance = await uChildDAI.allowance(jack, jill)
+      allowance.should.be.a.bignumber.that.equals(maxAmount)
+    })
+
+    it(`Admin should be able to block jill from spending jack's tokens using offline signature`, async() => {
+      const name = await uChildDAI.name()
+      const chainId = await uChildDAI.getChainId()
+      const nonce = await uChildDAI.getNonce(jack)
+
+      const sig = sigUtils.signTypedData(jackPK, {
+        data: getTypedData({
+          name,
+          version: '1',
+          chainId,
+          verifyingContract: uChildDAI.address,
+          nonce: '0x' + nonce.toString(16),
+          holder: jack,
+          spender: jill,
+          allowed: false
+        })
+      })
+      const { r, s, v } = getSignatureParameters(sig)
+      const tx = await uChildDAI.permit(jack, jill, nonce, 0, false, v, r, s, { from: admin })
+      should.exist(tx)
+    })
+
+    it('Allowance should be zero', async() => {
+      const allowance = await uChildDAI.allowance(jack, jill)
+      allowance.should.be.a.bignumber.that.equals(zeroAmount)
+    })
+  })
+})
+
+const getTypedData = ({ name, version, chainId, verifyingContract, nonce, holder, spender, expiry, allowed }) => {
+  return {
+    types: {
+      EIP712Domain: [{
+        name: 'name',
+        type: 'string'
+      }, {
+        name: 'version',
+        type: 'string'
+      }, {
+        name: 'verifyingContract',
+        type: 'address'
+      }, {
+        name: 'salt',
+        type: 'bytes32'
+      }],
+      Permit: [
+        {
+          name: 'holder',
+          type: 'address'
+        },
+        {
+          name: 'spender',
+          type: 'address'
+        },
+        {
+          name: 'nonce',
+          type: 'uint256'
+        },
+        {
+          name: 'expiry',
+          type: 'uint256'
+        },
+        {
+          name: 'allowed',
+          type: 'bool'
+        }
+      ]
+    },
+    domain: {
+      name,
+      version,
+      verifyingContract,
+      salt: '0x' + chainId.toString(16).padStart(64, '0')
+    },
+    primaryType: 'Permit',
+    message: {
+      holder,
+      spender,
+      nonce,
+      expiry: expiry || 0,
+      allowed
+    }
+  }
+}

--- a/test/child/UChildDAI.test.js
+++ b/test/child/UChildDAI.test.js
@@ -44,7 +44,7 @@ contract('UChildDAI', (accounts) => {
       const _symbol = await uChildDAI.symbol()
       _symbol.should.equal(symbol)
       const _decimals = await uChildDAI.decimals()
-      _decimals.should.equal(decimals)
+      _decimals.toNumber().should.equal(decimals)
     })
 
     it(`Admin should be able to permit jill to spend jack's tokens using offline signature`, async() => {

--- a/test/child/UChildDAI.test.js
+++ b/test/child/UChildDAI.test.js
@@ -40,7 +40,7 @@ contract('UChildDAI', (accounts) => {
 
     it('Contract should be initialized properly', async() => {
       const name = await uChildDAI.name()
-      name.should.equal(cinnamon)
+      name.should.equal(staranise)
       const _symbol = await uChildDAI.symbol()
       _symbol.should.equal(symbol)
       const _decimals = await uChildDAI.decimals()

--- a/test/child/UChildDAI.test.js
+++ b/test/child/UChildDAI.test.js
@@ -38,6 +38,15 @@ contract('UChildDAI', (accounts) => {
       await uChildDAI.changeName(staranise, { from: admin })
     })
 
+    it('Contract should be initialized properly', async() => {
+      const name = await uChildDAI.name()
+      name.should.equal(cinnamon)
+      const _symbol = await uChildDAI.symbol()
+      _symbol.should.equal(symbol)
+      const _decimals = await uChildDAI.decimals()
+      _decimals.should.equal(decimals)
+    })
+
     it(`Admin should be able to permit jill to spend jack's tokens using offline signature`, async() => {
       const name = await uChildDAI.name()
       const chainId = await uChildDAI.getChainId()

--- a/test/helpers/contracts.js
+++ b/test/helpers/contracts.js
@@ -28,6 +28,7 @@ const ChildERC20 = artifacts.require('ChildERC20')
 const UChildERC20 = artifacts.require('UChildERC20')
 const UChildERC20Proxy = artifacts.require('UChildERC20Proxy')
 const TestUChildERC20 = artifacts.require('TestUChildERC20')
+const UChildDAI = artifacts.require('UChildDAI')
 const ChildERC721 = artifacts.require('ChildERC721')
 const ChildMintableERC721 = artifacts.require('ChildMintableERC721')
 const ChildERC1155 = artifacts.require('ChildERC1155')
@@ -74,6 +75,7 @@ setWeb3(ChildERC20, childWeb3)
 setWeb3(UChildERC20, childWeb3)
 setWeb3(UChildERC20Proxy, childWeb3)
 setWeb3(TestUChildERC20, childWeb3)
+setWeb3(UChildDAI, childWeb3)
 setWeb3(ChildERC721, childWeb3)
 setWeb3(ChildMintableERC721, childWeb3)
 setWeb3(ChildERC1155, childWeb3)
@@ -104,6 +106,7 @@ export default {
   UChildERC20,
   UChildERC20Proxy,
   TestUChildERC20,
+  UChildDAI,
   ChildERC721,
   ChildMintableERC721,
   ChildERC1155,


### PR DESCRIPTION
- Took reference from https://github.com/makerdao/dss/blob/bbe8741d50240c995c8c78d5a96d1e532c8b0e88/src/dai.sol and implemented `push`, `pull`, `move`, `permit`.
- Domain separator in permit is changed to use `salt` instead of `chainId`, similar to this project's native meta tx.
- Same `nonces` as meta tx is reused here. This helps to keep same variable name as ethereum DAI. Also, not expecting anyone to use native meta tx for calling permit so it should be fine.