### PR TITLE
Erc721 batch deposit

### DIFF
--- a/contracts/child/ChildToken/ChildERC721.sol
+++ b/contracts/child/ChildToken/ChildERC721.sol
@@ -52,8 +52,19 @@ contract ChildERC721 is
         override
         only(DEPOSITOR_ROLE)
     {
-        uint256 tokenId = abi.decode(depositData, (uint256));
-        _mint(user, tokenId);
+        // deposit single
+        if (depositData.length == 32) {
+            uint256 tokenId = abi.decode(depositData, (uint256));
+            _mint(user, tokenId);
+
+        // deposit batch
+        } else {
+            uint256[] memory tokenIds = abi.decode(depositData, (uint256[]));
+            uint256 length = tokenIds.length;
+            for (uint256 i; i < length; i++) {
+                _mint(user, tokenIds[i]);
+            }
+        }
     }
 
     /**

--- a/contracts/root/TokenPredicates/ERC721Predicate.sol
+++ b/contracts/root/TokenPredicates/ERC721Predicate.sol
@@ -21,6 +21,12 @@ contract ERC721Predicate is ITokenPredicate, AccessControlMixin, Initializable, 
         address indexed rootToken,
         uint256 tokenId
     );
+    event LockedERC721Batch(
+        address indexed depositor,
+        address indexed depositReceiver,
+        address indexed rootToken,
+        uint256[] tokenIds
+    );
 
     constructor() public {}
 
@@ -63,9 +69,21 @@ contract ERC721Predicate is ITokenPredicate, AccessControlMixin, Initializable, 
         override
         only(MANAGER_ROLE)
     {
-        uint256 tokenId = abi.decode(depositData, (uint256));
-        emit LockedERC721(depositor, depositReceiver, rootToken, tokenId);
-        IERC721(rootToken).safeTransferFrom(depositor, address(this), tokenId);
+        // deposit single
+        if (depositData.length == 32) {
+            uint256 tokenId = abi.decode(depositData, (uint256));
+            emit LockedERC721(depositor, depositReceiver, rootToken, tokenId);
+            IERC721(rootToken).safeTransferFrom(depositor, address(this), tokenId);
+
+        // deposit batch
+        } else {
+            uint256[] memory tokenIds = abi.decode(depositData, (uint256[]));
+            emit LockedERC721Batch(depositor, depositReceiver, rootToken, tokenIds);
+            uint256 length = tokenIds.length;
+            for (uint256 i; i < length; i++) {
+                IERC721(rootToken).safeTransferFrom(depositor, address(this), tokenIds[i]);
+            }
+        }
     }
 
     /**

--- a/contracts/root/TokenPredicates/ERC721Predicate.sol
+++ b/contracts/root/TokenPredicates/ERC721Predicate.sol
@@ -15,6 +15,9 @@ contract ERC721Predicate is ITokenPredicate, AccessControlMixin, Initializable, 
     bytes32 public constant TOKEN_TYPE = keccak256("ERC721");
     bytes32 public constant TRANSFER_EVENT_SIG = 0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef;
 
+    // limit batching of tokens due to gas limit restrictions
+    uint256 public constant BATCH_LIMIT = 20;
+
     event LockedERC721(
         address indexed depositor,
         address indexed depositReceiver,
@@ -80,6 +83,7 @@ contract ERC721Predicate is ITokenPredicate, AccessControlMixin, Initializable, 
             uint256[] memory tokenIds = abi.decode(depositData, (uint256[]));
             emit LockedERC721Batch(depositor, depositReceiver, rootToken, tokenIds);
             uint256 length = tokenIds.length;
+            require(length <= BATCH_LIMIT, "ERC721Predicate: EXCEEDS_BATCH_LIMIT");
             for (uint256 i; i < length; i++) {
                 IERC721(rootToken).safeTransferFrom(depositor, address(this), tokenIds[i]);
             }

--- a/flat/ChildERC721.sol
+++ b/flat/ChildERC721.sol
@@ -2168,8 +2168,19 @@ contract ChildERC721 is
         override
         only(DEPOSITOR_ROLE)
     {
-        uint256 tokenId = abi.decode(depositData, (uint256));
-        _mint(user, tokenId);
+        // deposit single
+        if (depositData.length == 32) {
+            uint256 tokenId = abi.decode(depositData, (uint256));
+            _mint(user, tokenId);
+
+        // deposit batch
+        } else {
+            uint256[] memory tokenIds = abi.decode(depositData, (uint256[]));
+            uint256 length = tokenIds.length;
+            for (uint256 i; i < length; i++) {
+                _mint(user, tokenIds[i]);
+            }
+        }
     }
 
     /**

--- a/flat/ERC721Predicate.sol
+++ b/flat/ERC721Predicate.sol
@@ -1174,6 +1174,9 @@ contract ERC721Predicate is ITokenPredicate, AccessControlMixin, Initializable, 
     bytes32 public constant TOKEN_TYPE = keccak256("ERC721");
     bytes32 public constant TRANSFER_EVENT_SIG = 0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef;
 
+    // limit batching of tokens due to gas limit restrictions
+    uint256 public constant BATCH_LIMIT = 20;
+
     event LockedERC721(
         address indexed depositor,
         address indexed depositReceiver,
@@ -1239,6 +1242,7 @@ contract ERC721Predicate is ITokenPredicate, AccessControlMixin, Initializable, 
             uint256[] memory tokenIds = abi.decode(depositData, (uint256[]));
             emit LockedERC721Batch(depositor, depositReceiver, rootToken, tokenIds);
             uint256 length = tokenIds.length;
+            require(length <= BATCH_LIMIT, "ERC721Predicate: EXCEEDS_BATCH_LIMIT");
             for (uint256 i; i < length; i++) {
                 IERC721(rootToken).safeTransferFrom(depositor, address(this), tokenIds[i]);
             }

--- a/test/child/ChildERC721.test.js
+++ b/test/child/ChildERC721.test.js
@@ -73,6 +73,98 @@ contract('ChildERC721', (accounts) => {
     })
   })
 
+  describe('Should mint tokens on batch deposit', () => {
+    const tokenId1 = mockValues.numbers[6]
+    const tokenId2 = mockValues.numbers[3]
+    const tokenId3 = mockValues.numbers[1]
+    const user = mockValues.addresses[3]
+    const depositData = abi.encode(
+      ['uint256[]'],
+      [
+        [tokenId1.toString(), tokenId2.toString(), tokenId3.toString()]
+      ]
+    )
+    let contracts
+    let depositTx
+    let transferLogs
+
+    before(async() => {
+      contracts = await deployer.deployFreshChildContracts(accounts)
+      const DEPOSITOR_ROLE = await contracts.dummyERC721.DEPOSITOR_ROLE()
+      await contracts.dummyERC721.grantRole(DEPOSITOR_ROLE, accounts[0])
+    })
+
+    it('Token should not exist before deposit', async() => {
+      await expectRevert(contracts.dummyERC721.ownerOf(tokenId1), 'ERC721: owner query for nonexistent token')
+      await expectRevert(contracts.dummyERC721.ownerOf(tokenId2), 'ERC721: owner query for nonexistent token')
+      await expectRevert(contracts.dummyERC721.ownerOf(tokenId3), 'ERC721: owner query for nonexistent token')
+    })
+
+    it('Can receive deposit tx', async() => {
+      depositTx = await contracts.dummyERC721.deposit(user, depositData)
+      should.exist(depositTx)
+    })
+
+    it('Should emit Transfer log', () => {
+      const logs = logDecoder.decodeLogs(depositTx.receipt.rawLogs)
+      transferLogs = logs.filter(l => l && l.event && l.event === 'Transfer')
+      should.exist(transferLogs)
+      transferLogs.length.should.equal(3)
+    })
+
+    describe('Correct values should be emitted in Transfer logs', () => {
+      it('Event should be emitted by correct contract', () => {
+        transferLogs.forEach(t => {
+          t.address.should.equal(
+            contracts.dummyERC721.address.toLowerCase()
+          )
+        })
+      })
+
+      it('Should emit proper From', () => {
+        transferLogs.forEach(t => {
+          t.args.from.should.equal(mockValues.zeroAddress)
+        })
+      })
+
+      it('Should emit proper To', () => {
+        transferLogs.forEach(t => {
+          t.args.to.should.equal(user)
+        })
+      })
+
+      it('Should emit correct tokenId', () => {
+        {
+          const transferLogTokenId = transferLogs[0].args.tokenId.toNumber()
+          transferLogTokenId.should.equal(tokenId1)
+        }
+        {
+          const transferLogTokenId = transferLogs[1].args.tokenId.toNumber()
+          transferLogTokenId.should.equal(tokenId2)
+        }
+        {
+          const transferLogTokenId = transferLogs[2].args.tokenId.toNumber()
+          transferLogTokenId.should.equal(tokenId3)
+        }
+      })
+    })
+
+    it('Deposit token should be credited to deposit receiver', async() => {
+      {
+        const owner = await contracts.dummyERC721.ownerOf(tokenId1)
+        owner.should.equal(user)
+      }
+      {
+        const owner = await contracts.dummyERC721.ownerOf(tokenId2)
+        owner.should.equal(user)
+      }
+      {
+        const owner = await contracts.dummyERC721.ownerOf(tokenId3)
+        owner.should.equal(user)
+      }
+    })
+  })
+
   describe('Deposit called by non depositor account', () => {
     const tokenId = mockValues.numbers[6]
     const user = mockValues.addresses[3]

--- a/test/predicates/ERC721Predicate.test.js
+++ b/test/predicates/ERC721Predicate.test.js
@@ -90,6 +90,107 @@ contract('ERC721Predicate', (accounts) => {
     })
   })
 
+  describe('batch lockTokens', () => {
+    const tokenId1 = mockValues.numbers[2]
+    const tokenId2 = mockValues.numbers[6]
+    const tokenId3 = mockValues.numbers[9]
+    const depositReceiver = mockValues.addresses[7]
+    const depositor = accounts[1]
+    let dummyERC721
+    let erc721Predicate
+    let lockTokensTx
+    let lockedLog
+
+    before(async() => {
+      const contracts = await deployer.deployFreshRootContracts(accounts)
+      dummyERC721 = contracts.dummyERC721
+      erc721Predicate = contracts.erc721Predicate
+      await dummyERC721.mint(tokenId1, { from: depositor })
+      await dummyERC721.mint(tokenId2, { from: depositor })
+      await dummyERC721.mint(tokenId3, { from: depositor })
+      await dummyERC721.setApprovalForAll(erc721Predicate.address, true, { from: depositor })
+    })
+
+    it('Depositor should have token', async() => {
+      {
+        const owner = await dummyERC721.ownerOf(tokenId1)
+        owner.should.equal(depositor)
+      }
+      {
+        const owner = await dummyERC721.ownerOf(tokenId2)
+        owner.should.equal(depositor)
+      }
+      {
+        const owner = await dummyERC721.ownerOf(tokenId3)
+        owner.should.equal(depositor)
+      }
+    })
+
+    it('Depositor should have approved token transfer', async() => {
+      const approved = await dummyERC721.isApprovedForAll(depositor, erc721Predicate.address)
+      approved.should.equal(true)
+    })
+
+    it('Should be able to receive lockTokens tx', async() => {
+      const depositData = abi.encode(
+        ['uint256[]'],
+        [
+          [tokenId1.toString(), tokenId2.toString(), tokenId3.toString()]
+        ]
+      )
+      lockTokensTx = await erc721Predicate.lockTokens(depositor, depositReceiver, dummyERC721.address, depositData)
+      should.exist(lockTokensTx)
+    })
+
+    it('Should emit LockedERC721Batch log', () => {
+      const logs = logDecoder.decodeLogs(lockTokensTx.receipt.rawLogs)
+      lockedLog = logs.find(l => l.event === 'LockedERC721Batch')
+      should.exist(lockedLog)
+    })
+
+    describe('Correct values should be emitted in LockedERC721Batch log', () => {
+      it('Event should be emitted by correct contract', () => {
+        lockedLog.address.should.equal(
+          erc721Predicate.address.toLowerCase()
+        )
+      })
+
+      it('Should emit proper depositor', () => {
+        lockedLog.args.depositor.should.equal(depositor)
+      })
+
+      it('Should emit correct tokenIds', () => {
+        const lockedLogTokenIds = lockedLog.args.tokenIds.map(t => t.toNumber())
+        lockedLogTokenIds.should.include(tokenId1)
+        lockedLogTokenIds.should.include(tokenId2)
+        lockedLogTokenIds.should.include(tokenId3)
+      })
+
+      it('Should emit correct deposit receiver', () => {
+        lockedLog.args.depositReceiver.should.equal(depositReceiver)
+      })
+
+      it('Should emit correct root token', () => {
+        lockedLog.args.rootToken.should.equal(dummyERC721.address)
+      })
+    })
+
+    it('token should be transferred to correct contract', async() => {
+      {
+        const owner = await dummyERC721.ownerOf(tokenId1)
+        owner.should.equal(erc721Predicate.address)
+      }
+      {
+        const owner = await dummyERC721.ownerOf(tokenId2)
+        owner.should.equal(erc721Predicate.address)
+      }
+      {
+        const owner = await dummyERC721.ownerOf(tokenId3)
+        owner.should.equal(erc721Predicate.address)
+      }
+    })
+  })
+
   describe('lockTokens called by non manager', () => {
     const tokenId = mockValues.numbers[5]
     const depositor = accounts[1]


### PR DESCRIPTION
ERC721 predicate and child token check if `depositData` length is 32 bytes. If it is then it is assumed the deposit is being done for single token id. If length is more, it is assumed that the deposit is for a list of token ids.