### PR TITLE
ERC721 batch withdraw

### DIFF
--- a/contracts/child/ChildToken/ChildERC721.sol
+++ b/contracts/child/ChildToken/ChildERC721.sol
@@ -17,6 +17,14 @@ contract ChildERC721 is
 {
     bytes32 public constant DEPOSITOR_ROLE = keccak256("DEPOSITOR_ROLE");
 
+    // limit batching of tokens due to gas limit restrictions
+    uint256 public constant BATCH_LIMIT = 20;
+
+    event WithdrawnBatch(
+        address indexed user,
+        uint256[] tokenIds
+    );
+
     constructor(
         string memory name_,
         string memory symbol_,
@@ -75,5 +83,21 @@ contract ChildERC721 is
     function withdraw(uint256 tokenId) external {
         require(_msgSender() == ownerOf(tokenId), "ChildERC721: INVALID_TOKEN_OWNER");
         _burn(tokenId);
+    }
+
+    /**
+     * @notice called when user wants to withdraw multiple tokens back to root chain
+     * @dev Should burn user's tokens. This transaction will be verified when exiting on root chain
+     * @param tokenIds tokenId list to withdraw
+     */
+    function withdrawBatch(uint256[] calldata tokenIds) external {
+        uint256 length = tokenIds.length;
+        require(length <= BATCH_LIMIT, "ChildERC721: EXCEEDS_BATCH_LIMIT");
+        for (uint256 i; i < length; i++) {
+            uint256 tokenId = tokenIds[i];
+            require(_msgSender() == ownerOf(tokenId), string(abi.encodePacked("ChildERC721: INVALID_TOKEN_OWNER ", tokenId)));
+            _burn(tokenId);
+        }
+        emit WithdrawnBatch(_msgSender(), tokenIds);
     }
 }

--- a/contracts/root/TokenPredicates/ERC721Predicate.sol
+++ b/contracts/root/TokenPredicates/ERC721Predicate.sol
@@ -14,6 +14,7 @@ contract ERC721Predicate is ITokenPredicate, AccessControlMixin, Initializable, 
     bytes32 public constant MANAGER_ROLE = keccak256("MANAGER_ROLE");
     bytes32 public constant TOKEN_TYPE = keccak256("ERC721");
     bytes32 public constant TRANSFER_EVENT_SIG = 0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef;
+    bytes32 public constant WITHDRAW_BATCH_EVENT_SIG = 0xf871896b17e9cb7a64941c62c188a4f5c621b86800e3d15452ece01ce56073df;
 
     // limit batching of tokens due to gas limit restrictions
     uint256 public constant BATCH_LIMIT = 20;
@@ -110,23 +111,36 @@ contract ERC721Predicate is ITokenPredicate, AccessControlMixin, Initializable, 
         RLPReader.RLPItem[] memory logRLPList = log.toRlpItem().toList();
         RLPReader.RLPItem[] memory logTopicRLPList = logRLPList[1].toList(); // topics
 
-        require(
-            bytes32(logTopicRLPList[0].toUint()) == TRANSFER_EVENT_SIG, // topic0 is event sig
-            "ERC721Predicate: INVALID_SIGNATURE"
-        );
-        require(
-            withdrawer == address(logTopicRLPList[1].toUint()), // topic1 is from address
-            "ERC721Predicate: INVALID_SENDER"
-        );
-        require(
-            address(logTopicRLPList[2].toUint()) == address(0), // topic2 is to address
-            "ERC721Predicate: INVALID_RECEIVER"
-        );
+        if (bytes32(logTopicRLPList[0].toUint()) == TRANSFER_EVENT_SIG) { // topic0 is event sig
+            require(
+                withdrawer == address(logTopicRLPList[1].toUint()), // topic1 is from address
+                "ERC721Predicate: INVALID_SENDER"
+            );
+            require(
+                address(logTopicRLPList[2].toUint()) == address(0), // topic2 is to address
+                "ERC721Predicate: INVALID_RECEIVER"
+            );
 
-        IERC721(rootToken).safeTransferFrom(
-            address(this),
-            withdrawer,
-            logTopicRLPList[3].toUint() // topic3 is tokenId field
-        );
+            IERC721(rootToken).safeTransferFrom(
+                address(this),
+                withdrawer,
+                logTopicRLPList[3].toUint() // topic3 is tokenId field
+            );
+
+        } else if (bytes32(logTopicRLPList[0].toUint()) == WITHDRAW_BATCH_EVENT_SIG) { // topic0 is event sig
+            require(
+                withdrawer == address(logTopicRLPList[1].toUint()), // topic1 is user address
+                "ERC721Predicate: INVALID_SENDER"
+            );
+            bytes memory logData = logRLPList[2].toBytes();
+            (uint256[] memory tokenIds) = abi.decode(logData, (uint256[])); // data is tokenId list
+            uint256 length = tokenIds.length;
+            for (uint256 i; i < length; i++) {
+                IERC721(rootToken).safeTransferFrom(address(this), withdrawer, tokenIds[i]);
+            }
+
+        } else {
+            revert("ERC721Predicate: INVALID_SIGNATURE");
+        }
     }
 }

--- a/test/root/Withdraw.test.js
+++ b/test/root/Withdraw.test.js
@@ -648,7 +648,7 @@ contract('RootChainManager', async(accounts) => {
     })
   })
 
-  describe.only('Withdraw batch ERC721', async() => {
+  describe('Withdraw batch ERC721', async() => {
     const tokenId1 = mockValues.numbers[4]
     const tokenId2 = mockValues.numbers[5]
     const tokenId3 = mockValues.numbers[8]


### PR DESCRIPTION
Burn multiple tokens in one go by calling `withdrawBatch` function on child token. This emits an event `WithdrawnBatch`. Predicate checks if event signature is for `Transfer` or `WithdrawnBatch` and processes exit based on that.