### PR TITLE
feat: allow anyone to exit

### DIFF
--- a/contracts/root/TokenPredicates/ERC1155Predicate.sol
+++ b/contracts/root/TokenPredicates/ERC1155Predicate.sol
@@ -104,12 +104,11 @@ contract ERC1155Predicate is ITokenPredicate, ERC1155Receiver, AccessControlMixi
      * @notice Validates log signature, from and to address
      * then sends the correct tokenId, amount to withdrawer
      * callable only by manager
-     * @param withdrawer Address who wants to withdraw tokens
      * @param rootToken Token which gets withdrawn
      * @param log Valid ERC1155 TransferSingle burn or TransferBatch burn log from child chain
      */
     function exitTokens(
-        address withdrawer,
+        address,
         address rootToken,
         bytes memory log
     )
@@ -121,10 +120,8 @@ contract ERC1155Predicate is ITokenPredicate, ERC1155Receiver, AccessControlMixi
         RLPReader.RLPItem[] memory logTopicRLPList = logRLPList[1].toList(); // topics
         bytes memory logData = logRLPList[2].toBytes();
 
-        require(
-            withdrawer == address(logTopicRLPList[2].toUint()), // topic2 is from address
-            "ERC1155Predicate: INVALID_SENDER"
-        );
+        address withdrawer = address(logTopicRLPList[2].toUint()); // topic2 is from address
+
         require(
             address(logTopicRLPList[3].toUint()) == address(0), // topic3 is to address
             "ERC1155Predicate: INVALID_RECEIVER"

--- a/contracts/root/TokenPredicates/ERC20Predicate.sol
+++ b/contracts/root/TokenPredicates/ERC20Predicate.sol
@@ -57,12 +57,11 @@ contract ERC20Predicate is ITokenPredicate, AccessControlMixin, Initializable {
      * @notice Validates log signature, from and to address
      * then sends the correct amount to withdrawer
      * callable only by manager
-     * @param withdrawer Address who wants to withdraw tokens
      * @param rootToken Token which gets withdrawn
      * @param log Valid ERC20 burn log from child chain
      */
     function exitTokens(
-        address withdrawer,
+        address,
         address rootToken,
         bytes memory log
     )
@@ -77,10 +76,9 @@ contract ERC20Predicate is ITokenPredicate, AccessControlMixin, Initializable {
             bytes32(logTopicRLPList[0].toUint()) == TRANSFER_EVENT_SIG, // topic0 is event sig
             "ERC20Predicate: INVALID_SIGNATURE"
         );
-        require(
-            withdrawer == address(logTopicRLPList[1].toUint()), // topic1 is from address
-            "ERC20Predicate: INVALID_SENDER"
-        );
+
+        address withdrawer = address(logTopicRLPList[1].toUint()); // topic1 is from address
+
         require(
             address(logTopicRLPList[2].toUint()) == address(0), // topic2 is to address
             "ERC20Predicate: INVALID_RECEIVER"

--- a/contracts/root/TokenPredicates/ERC721Predicate.sol
+++ b/contracts/root/TokenPredicates/ERC721Predicate.sol
@@ -95,12 +95,11 @@ contract ERC721Predicate is ITokenPredicate, AccessControlMixin, Initializable, 
      * @notice Validates log signature, from and to address
      * then sends the correct tokenId to withdrawer
      * callable only by manager
-     * @param withdrawer Address who wants to withdraw token
      * @param rootToken Token which gets withdrawn
      * @param log Valid ERC721 burn log from child chain
      */
     function exitTokens(
-        address withdrawer,
+        address,
         address rootToken,
         bytes memory log
     )
@@ -110,12 +109,9 @@ contract ERC721Predicate is ITokenPredicate, AccessControlMixin, Initializable, 
     {
         RLPReader.RLPItem[] memory logRLPList = log.toRlpItem().toList();
         RLPReader.RLPItem[] memory logTopicRLPList = logRLPList[1].toList(); // topics
+        address withdrawer = address(logTopicRLPList[1].toUint()); // topic1 is from address
 
         if (bytes32(logTopicRLPList[0].toUint()) == TRANSFER_EVENT_SIG) { // topic0 is event sig
-            require(
-                withdrawer == address(logTopicRLPList[1].toUint()), // topic1 is from address
-                "ERC721Predicate: INVALID_SENDER"
-            );
             require(
                 address(logTopicRLPList[2].toUint()) == address(0), // topic2 is to address
                 "ERC721Predicate: INVALID_RECEIVER"
@@ -128,10 +124,6 @@ contract ERC721Predicate is ITokenPredicate, AccessControlMixin, Initializable, 
             );
 
         } else if (bytes32(logTopicRLPList[0].toUint()) == WITHDRAW_BATCH_EVENT_SIG) { // topic0 is event sig
-            require(
-                withdrawer == address(logTopicRLPList[1].toUint()), // topic1 is user address
-                "ERC721Predicate: INVALID_SENDER"
-            );
             bytes memory logData = logRLPList[2].toBytes();
             (uint256[] memory tokenIds) = abi.decode(logData, (uint256[])); // data is tokenId list
             uint256 length = tokenIds.length;

--- a/contracts/root/TokenPredicates/EtherPredicate.sol
+++ b/contracts/root/TokenPredicates/EtherPredicate.sol
@@ -61,11 +61,10 @@ contract EtherPredicate is ITokenPredicate, AccessControlMixin, Initializable {
      * @notice Validates log signature, from and to address
      * then sends the correct amount to withdrawer
      * callable only by manager
-     * @param withdrawer Address who wants to withdraw tokens
      * @param log Valid ERC20 burn log from child chain
      */
     function exitTokens(
-        address withdrawer,
+        address,
         address,
         bytes memory log
     )
@@ -80,10 +79,9 @@ contract EtherPredicate is ITokenPredicate, AccessControlMixin, Initializable {
             bytes32(logTopicRLPList[0].toUint()) == TRANSFER_EVENT_SIG, // topic0 is event sig
             "EtherPredicate: INVALID_SIGNATURE"
         );
-        require(
-            withdrawer == address(logTopicRLPList[1].toUint()), // topic1 is from address
-            "EtherPredicate: INVALID_SENDER"
-        );
+
+        address withdrawer = address(logTopicRLPList[1].toUint()); // topic1 is from address
+
         require(
             address(logTopicRLPList[2].toUint()) == address(0), // topic2 is to address
             "EtherPredicate: INVALID_RECEIVER"

--- a/contracts/root/TokenPredicates/ITokenPredicate.sol
+++ b/contracts/root/TokenPredicates/ITokenPredicate.sol
@@ -25,12 +25,12 @@ interface ITokenPredicate {
      * @notice Validates and processes exit while withdraw process
      * @dev Validates exit log emitted on sidechain. Reverts if validation fails.
      * @dev Processes withdraw based on custom logic. Example: transfer ERC20/ERC721, mint ERC721 if mintable withdraw
-     * @param withdrawer Address who wants to withdraw tokens
+     * @param sender Address
      * @param rootToken Token which gets withdrawn
      * @param logRLPList Valid sidechain log for data like amount, token id etc.
      */
     function exitTokens(
-        address withdrawer,
+        address sender,
         address rootToken,
         bytes calldata logRLPList
     ) external;

--- a/contracts/root/TokenPredicates/MintableERC721Predicate.sol
+++ b/contracts/root/TokenPredicates/MintableERC721Predicate.sol
@@ -77,12 +77,11 @@ contract MintableERC721Predicate is ITokenPredicate, AccessControlMixin, Initial
      * if token exits then transfers it to withdrawer
      * if token doesn't exit then it is minted
      * callable only by manager
-     * @param withdrawer Address who wants to withdraw token
      * @param rootToken Token which gets withdrawn
      * @param log Valid ERC721 burn log from child chain
      */
     function exitTokens(
-        address withdrawer,
+        address,
         address rootToken,
         bytes memory log
     )
@@ -97,10 +96,9 @@ contract MintableERC721Predicate is ITokenPredicate, AccessControlMixin, Initial
             bytes32(logTopicRLPList[0].toUint()) == TRANSFER_EVENT_SIG, // topic0 is event sig
             "MintableERC721Predicate: INVALID_SIGNATURE"
         );
-        require(
-            withdrawer == address(logTopicRLPList[1].toUint()), // topic1 is from address
-            "MintableERC721Predicate: INVALID_SENDER"
-        );
+
+        address withdrawer = address(logTopicRLPList[1].toUint()); // topic1 is from address
+
         require(
             address(logTopicRLPList[2].toUint()) == address(0), // topic2 is to address
             "MintableERC721Predicate: INVALID_RECEIVER"

--- a/flat/ERC1155Predicate.sol
+++ b/flat/ERC1155Predicate.sol
@@ -1347,12 +1347,12 @@ contract ERC1155Predicate is ITokenPredicate, ERC1155Receiver, AccessControlMixi
      * @notice Validates log signature, from and to address
      * then sends the correct tokenId, amount to withdrawer
      * callable only by manager
-     * @param withdrawer Address who wants to withdraw tokens
+     * @param sender Address
      * @param rootToken Token which gets withdrawn
      * @param log Valid ERC1155 TransferSingle burn or TransferBatch burn log from child chain
      */
     function exitTokens(
-        address withdrawer,
+        address,
         address rootToken,
         bytes memory log
     )
@@ -1364,10 +1364,8 @@ contract ERC1155Predicate is ITokenPredicate, ERC1155Receiver, AccessControlMixi
         RLPReader.RLPItem[] memory logTopicRLPList = logRLPList[1].toList(); // topics
         bytes memory logData = logRLPList[2].toBytes();
 
-        require(
-            withdrawer == address(logTopicRLPList[2].toUint()), // topic2 is from address
-            "ERC1155Predicate: INVALID_SENDER"
-        );
+        address withdrawer = address(logTopicRLPList[2].toUint()); // topic2 is from address
+
         require(
             address(logTopicRLPList[3].toUint()) == address(0), // topic3 is to address
             "ERC1155Predicate: INVALID_RECEIVER"

--- a/flat/ERC1155Predicate.sol
+++ b/flat/ERC1155Predicate.sol
@@ -1215,12 +1215,12 @@ interface ITokenPredicate {
      * @notice Validates and processes exit while withdraw process
      * @dev Validates exit log emitted on sidechain. Reverts if validation fails.
      * @dev Processes withdraw based on custom logic. Example: transfer ERC20/ERC721, mint ERC721 if mintable withdraw
-     * @param withdrawer Address who wants to withdraw tokens
+     * @param sender Address
      * @param rootToken Token which gets withdrawn
      * @param logRLPList Valid sidechain log for data like amount, token id etc.
      */
     function exitTokens(
-        address withdrawer,
+        address sender,
         address rootToken,
         bytes calldata logRLPList
     ) external;
@@ -1347,7 +1347,6 @@ contract ERC1155Predicate is ITokenPredicate, ERC1155Receiver, AccessControlMixi
      * @notice Validates log signature, from and to address
      * then sends the correct tokenId, amount to withdrawer
      * callable only by manager
-     * @param sender Address
      * @param rootToken Token which gets withdrawn
      * @param log Valid ERC1155 TransferSingle burn or TransferBatch burn log from child chain
      */

--- a/flat/ERC20Predicate.sol
+++ b/flat/ERC20Predicate.sol
@@ -1267,12 +1267,12 @@ interface ITokenPredicate {
      * @notice Validates and processes exit while withdraw process
      * @dev Validates exit log emitted on sidechain. Reverts if validation fails.
      * @dev Processes withdraw based on custom logic. Example: transfer ERC20/ERC721, mint ERC721 if mintable withdraw
-     * @param withdrawer Address who wants to withdraw tokens
+     * @param sender Address
      * @param rootToken Token which gets withdrawn
      * @param logRLPList Valid sidechain log for data like amount, token id etc.
      */
     function exitTokens(
-        address withdrawer,
+        address sender,
         address rootToken,
         bytes calldata logRLPList
     ) external;
@@ -1352,7 +1352,6 @@ contract ERC20Predicate is ITokenPredicate, AccessControlMixin, Initializable {
      * @notice Validates log signature, from and to address
      * then sends the correct amount to withdrawer
      * callable only by manager
-     * @param sender Address
      * @param rootToken Token which gets withdrawn
      * @param log Valid ERC20 burn log from child chain
      */

--- a/flat/ERC20Predicate.sol
+++ b/flat/ERC20Predicate.sol
@@ -1352,12 +1352,12 @@ contract ERC20Predicate is ITokenPredicate, AccessControlMixin, Initializable {
      * @notice Validates log signature, from and to address
      * then sends the correct amount to withdrawer
      * callable only by manager
-     * @param withdrawer Address who wants to withdraw tokens
+     * @param sender Address
      * @param rootToken Token which gets withdrawn
      * @param log Valid ERC20 burn log from child chain
      */
     function exitTokens(
-        address withdrawer,
+        address,
         address rootToken,
         bytes memory log
     )
@@ -1372,10 +1372,9 @@ contract ERC20Predicate is ITokenPredicate, AccessControlMixin, Initializable {
             bytes32(logTopicRLPList[0].toUint()) == TRANSFER_EVENT_SIG, // topic0 is event sig
             "ERC20Predicate: INVALID_SIGNATURE"
         );
-        require(
-            withdrawer == address(logTopicRLPList[1].toUint()), // topic1 is from address
-            "ERC20Predicate: INVALID_SENDER"
-        );
+
+        address withdrawer = address(logTopicRLPList[1].toUint()); // topic1 is from address
+
         require(
             address(logTopicRLPList[2].toUint()) == address(0), // topic2 is to address
             "ERC20Predicate: INVALID_RECEIVER"

--- a/flat/ERC721Predicate.sol
+++ b/flat/ERC721Predicate.sol
@@ -1254,12 +1254,12 @@ contract ERC721Predicate is ITokenPredicate, AccessControlMixin, Initializable, 
      * @notice Validates log signature, from and to address
      * then sends the correct tokenId to withdrawer
      * callable only by manager
-     * @param withdrawer Address who wants to withdraw token
+     * @param sender Address
      * @param rootToken Token which gets withdrawn
      * @param log Valid ERC721 burn log from child chain
      */
     function exitTokens(
-        address withdrawer,
+        address,
         address rootToken,
         bytes memory log
     )
@@ -1269,12 +1269,9 @@ contract ERC721Predicate is ITokenPredicate, AccessControlMixin, Initializable, 
     {
         RLPReader.RLPItem[] memory logRLPList = log.toRlpItem().toList();
         RLPReader.RLPItem[] memory logTopicRLPList = logRLPList[1].toList(); // topics
+        address withdrawer = address(logTopicRLPList[1].toUint()); // topic1 is from address
 
         if (bytes32(logTopicRLPList[0].toUint()) == TRANSFER_EVENT_SIG) { // topic0 is event sig
-            require(
-                withdrawer == address(logTopicRLPList[1].toUint()), // topic1 is from address
-                "ERC721Predicate: INVALID_SENDER"
-            );
             require(
                 address(logTopicRLPList[2].toUint()) == address(0), // topic2 is to address
                 "ERC721Predicate: INVALID_RECEIVER"
@@ -1287,10 +1284,6 @@ contract ERC721Predicate is ITokenPredicate, AccessControlMixin, Initializable, 
             );
 
         } else if (bytes32(logTopicRLPList[0].toUint()) == WITHDRAW_BATCH_EVENT_SIG) { // topic0 is event sig
-            require(
-                withdrawer == address(logTopicRLPList[1].toUint()), // topic1 is user address
-                "ERC721Predicate: INVALID_SENDER"
-            );
             bytes memory logData = logRLPList[2].toBytes();
             (uint256[] memory tokenIds) = abi.decode(logData, (uint256[])); // data is tokenId list
             uint256 length = tokenIds.length;

--- a/flat/ERC721Predicate.sol
+++ b/flat/ERC721Predicate.sol
@@ -475,12 +475,12 @@ interface ITokenPredicate {
      * @notice Validates and processes exit while withdraw process
      * @dev Validates exit log emitted on sidechain. Reverts if validation fails.
      * @dev Processes withdraw based on custom logic. Example: transfer ERC20/ERC721, mint ERC721 if mintable withdraw
-     * @param withdrawer Address who wants to withdraw tokens
+     * @param sender Address
      * @param rootToken Token which gets withdrawn
      * @param logRLPList Valid sidechain log for data like amount, token id etc.
      */
     function exitTokens(
-        address withdrawer,
+        address sender,
         address rootToken,
         bytes calldata logRLPList
     ) external;
@@ -1254,7 +1254,6 @@ contract ERC721Predicate is ITokenPredicate, AccessControlMixin, Initializable, 
      * @notice Validates log signature, from and to address
      * then sends the correct tokenId to withdrawer
      * callable only by manager
-     * @param sender Address
      * @param rootToken Token which gets withdrawn
      * @param log Valid ERC721 burn log from child chain
      */

--- a/flat/EtherPredicate.sol
+++ b/flat/EtherPredicate.sol
@@ -1037,11 +1037,12 @@ contract EtherPredicate is ITokenPredicate, AccessControlMixin, Initializable {
      * @notice Validates log signature, from and to address
      * then sends the correct amount to withdrawer
      * callable only by manager
+     * @param sender Address
      * @param withdrawer Address who wants to withdraw tokens
      * @param log Valid ERC20 burn log from child chain
      */
     function exitTokens(
-        address withdrawer,
+        address,
         address,
         bytes memory log
     )
@@ -1056,10 +1057,9 @@ contract EtherPredicate is ITokenPredicate, AccessControlMixin, Initializable {
             bytes32(logTopicRLPList[0].toUint()) == TRANSFER_EVENT_SIG, // topic0 is event sig
             "EtherPredicate: INVALID_SIGNATURE"
         );
-        require(
-            withdrawer == address(logTopicRLPList[1].toUint()), // topic1 is from address
-            "EtherPredicate: INVALID_SENDER"
-        );
+
+        address withdrawer = address(logTopicRLPList[1].toUint()); // topic1 is from address
+
         require(
             address(logTopicRLPList[2].toUint()) == address(0), // topic2 is to address
             "EtherPredicate: INVALID_RECEIVER"

--- a/flat/EtherPredicate.sol
+++ b/flat/EtherPredicate.sol
@@ -948,12 +948,12 @@ interface ITokenPredicate {
      * @notice Validates and processes exit while withdraw process
      * @dev Validates exit log emitted on sidechain. Reverts if validation fails.
      * @dev Processes withdraw based on custom logic. Example: transfer ERC20/ERC721, mint ERC721 if mintable withdraw
-     * @param withdrawer Address who wants to withdraw tokens
+     * @param sender Address
      * @param rootToken Token which gets withdrawn
      * @param logRLPList Valid sidechain log for data like amount, token id etc.
      */
     function exitTokens(
-        address withdrawer,
+        address sender,
         address rootToken,
         bytes calldata logRLPList
     ) external;
@@ -1037,8 +1037,6 @@ contract EtherPredicate is ITokenPredicate, AccessControlMixin, Initializable {
      * @notice Validates log signature, from and to address
      * then sends the correct amount to withdrawer
      * callable only by manager
-     * @param sender Address
-     * @param withdrawer Address who wants to withdraw tokens
      * @param log Valid ERC20 burn log from child chain
      */
     function exitTokens(

--- a/flat/MintableERC721Predicate.sol
+++ b/flat/MintableERC721Predicate.sol
@@ -1258,12 +1258,12 @@ contract MintableERC721Predicate is ITokenPredicate, AccessControlMixin, Initial
      * if token exits then transfers it to withdrawer
      * if token doesn't exit then it is minted
      * callable only by manager
-     * @param withdrawer Address who wants to withdraw token
+     * @param sender Address
      * @param rootToken Token which gets withdrawn
      * @param log Valid ERC721 burn log from child chain
      */
     function exitTokens(
-        address withdrawer,
+        address,
         address rootToken,
         bytes memory log
     )
@@ -1278,10 +1278,9 @@ contract MintableERC721Predicate is ITokenPredicate, AccessControlMixin, Initial
             bytes32(logTopicRLPList[0].toUint()) == TRANSFER_EVENT_SIG, // topic0 is event sig
             "MintableERC721Predicate: INVALID_SIGNATURE"
         );
-        require(
-            withdrawer == address(logTopicRLPList[1].toUint()), // topic1 is from address
-            "MintableERC721Predicate: INVALID_SENDER"
-        );
+
+        address withdrawer = address(logTopicRLPList[1].toUint()); // topic1 is from address
+
         require(
             address(logTopicRLPList[2].toUint()) == address(0), // topic2 is to address
             "MintableERC721Predicate: INVALID_RECEIVER"

--- a/flat/MintableERC721Predicate.sol
+++ b/flat/MintableERC721Predicate.sol
@@ -1153,12 +1153,12 @@ interface ITokenPredicate {
      * @notice Validates and processes exit while withdraw process
      * @dev Validates exit log emitted on sidechain. Reverts if validation fails.
      * @dev Processes withdraw based on custom logic. Example: transfer ERC20/ERC721, mint ERC721 if mintable withdraw
-     * @param withdrawer Address who wants to withdraw tokens
+     * @param sender Address
      * @param rootToken Token which gets withdrawn
      * @param logRLPList Valid sidechain log for data like amount, token id etc.
      */
     function exitTokens(
-        address withdrawer,
+        address sender,
         address rootToken,
         bytes calldata logRLPList
     ) external;
@@ -1258,7 +1258,6 @@ contract MintableERC721Predicate is ITokenPredicate, AccessControlMixin, Initial
      * if token exits then transfers it to withdrawer
      * if token doesn't exit then it is minted
      * callable only by manager
-     * @param sender Address
      * @param rootToken Token which gets withdrawn
      * @param log Valid ERC721 burn log from child chain
      */

--- a/flat/RootChainManager.sol
+++ b/flat/RootChainManager.sol
@@ -742,12 +742,12 @@ interface ITokenPredicate {
      * @notice Validates and processes exit while withdraw process
      * @dev Validates exit log emitted on sidechain. Reverts if validation fails.
      * @dev Processes withdraw based on custom logic. Example: transfer ERC20/ERC721, mint ERC721 if mintable withdraw
-     * @param withdrawer Address who wants to withdraw tokens
+     * @param sender Address
      * @param rootToken Token which gets withdrawn
      * @param logRLPList Valid sidechain log for data like amount, token id etc.
      */
     function exitTokens(
-        address withdrawer,
+        address sender,
         address rootToken,
         bytes calldata logRLPList
     ) external;

--- a/test/predicates/ERC1155Predicate.test.js
+++ b/test/predicates/ERC1155Predicate.test.js
@@ -315,7 +315,7 @@ contract('ERC1155Predicate', (accounts) => {
     let oldAccountBalanceA
     let oldAccountBalanceB
     let oldContractBalanceA
-    let oldContractBalanceB    
+    let oldContractBalanceB
 
     before(async() => {
       const contracts = await deployer.deployFreshRootContracts(accounts)
@@ -371,7 +371,6 @@ contract('ERC1155Predicate', (accounts) => {
       )
     })
   })
-
 
   describe('exitTokens with incorrect burn transaction signature', () => {
     const withdrawAmount = mockValues.amounts[9]

--- a/test/predicates/ERC20Predicate.test.js
+++ b/test/predicates/ERC20Predicate.test.js
@@ -181,6 +181,9 @@ contract('ERC20Predicate', (accounts) => {
     const exitCaller = mockValues.addresses[3]
     let dummyERC20
     let erc20Predicate
+    let oldAccountBalance
+    let oldContractBalance
+    let exitTokensTx
 
     before(async() => {
       const contracts = await deployer.deployFreshRootContracts(accounts)
@@ -189,6 +192,8 @@ contract('ERC20Predicate', (accounts) => {
       await dummyERC20.approve(erc20Predicate.address, depositAmount)
       const depositData = abi.encode(['uint256'], [depositAmount.toString()])
       await erc20Predicate.lockTokens(accounts[0], withdrawer, dummyERC20.address, depositData)
+      oldAccountBalance = await dummyERC20.balanceOf(withdrawer)
+      oldContractBalance = await dummyERC20.balanceOf(erc20Predicate.address)
     })
 
     it('Should be able to receive exitTokens tx', async() => {

--- a/test/predicates/ERC20Predicate.test.js
+++ b/test/predicates/ERC20Predicate.test.js
@@ -174,6 +174,48 @@ contract('ERC20Predicate', (accounts) => {
     })
   })
 
+  describe('exitTokens called by different user', () => {
+    const withdrawAmount = mockValues.amounts[2]
+    const depositAmount = withdrawAmount.add(mockValues.amounts[3])
+    const withdrawer = mockValues.addresses[8]
+    const exitCaller = mockValues.addresses[3]
+    let dummyERC20
+    let erc20Predicate
+
+    before(async() => {
+      const contracts = await deployer.deployFreshRootContracts(accounts)
+      dummyERC20 = contracts.dummyERC20
+      erc20Predicate = contracts.erc20Predicate
+      await dummyERC20.approve(erc20Predicate.address, depositAmount)
+      const depositData = abi.encode(['uint256'], [depositAmount.toString()])
+      await erc20Predicate.lockTokens(accounts[0], withdrawer, dummyERC20.address, depositData)
+    })
+
+    it('Should be able to receive exitTokens tx', async() => {
+      const burnLog = getERC20TransferLog({
+        from: withdrawer,
+        to: mockValues.zeroAddress,
+        amount: withdrawAmount
+      })
+      exitTokensTx = await erc20Predicate.exitTokens(exitCaller, dummyERC20.address, burnLog)
+      should.exist(exitTokensTx)
+    })
+
+    it('Withdraw amount should be deducted from contract', async() => {
+      const newContractBalance = await dummyERC20.balanceOf(erc20Predicate.address)
+      newContractBalance.should.be.a.bignumber.that.equals(
+        oldContractBalance.sub(withdrawAmount)
+      )
+    })
+
+    it('Withdraw amount should be credited to correct address', async() => {
+      const newAccountBalance = await dummyERC20.balanceOf(withdrawer)
+      newAccountBalance.should.be.a.bignumber.that.equals(
+        oldAccountBalance.add(withdrawAmount)
+      )
+    })
+  })
+
   describe('exitTokens with incorrect burn transaction signature', () => {
     const withdrawAmount = mockValues.amounts[2]
     const depositAmount = withdrawAmount.add(mockValues.amounts[3])
@@ -201,32 +243,6 @@ contract('ERC20Predicate', (accounts) => {
     })
   })
 
-  describe('exitTokens called by different user', () => {
-    const withdrawAmount = mockValues.amounts[2]
-    const depositAmount = withdrawAmount.add(mockValues.amounts[3])
-    const withdrawer = mockValues.addresses[8]
-    const exitCaller = mockValues.addresses[3]
-    let dummyERC20
-    let erc20Predicate
-
-    before(async() => {
-      const contracts = await deployer.deployFreshRootContracts(accounts)
-      dummyERC20 = contracts.dummyERC20
-      erc20Predicate = contracts.erc20Predicate
-      await dummyERC20.approve(erc20Predicate.address, depositAmount)
-      const depositData = abi.encode(['uint256'], [depositAmount.toString()])
-      await erc20Predicate.lockTokens(accounts[0], withdrawer, dummyERC20.address, depositData)
-    })
-
-    it('Should revert with correct reason', async() => {
-      const burnLog = getERC20TransferLog({
-        from: withdrawer,
-        to: mockValues.zeroAddress,
-        amount: withdrawAmount
-      })
-      await expectRevert(erc20Predicate.exitTokens(exitCaller, dummyERC20.address, burnLog), 'ERC20Predicate: INVALID_SENDER')
-    })
-  })
 
   describe('exitTokens called using normal transfer log instead of burn', () => {
     const withdrawAmount = mockValues.amounts[2]

--- a/test/predicates/ERC20Predicate.test.js
+++ b/test/predicates/ERC20Predicate.test.js
@@ -243,7 +243,6 @@ contract('ERC20Predicate', (accounts) => {
     })
   })
 
-
   describe('exitTokens called using normal transfer log instead of burn', () => {
     const withdrawAmount = mockValues.amounts[2]
     const depositAmount = withdrawAmount.add(mockValues.amounts[3])

--- a/test/predicates/ERC721Predicate.test.js
+++ b/test/predicates/ERC721Predicate.test.js
@@ -252,6 +252,41 @@ contract('ERC721Predicate', (accounts) => {
     })
   })
 
+  describe('exitTokens called by different user', () => {
+    const tokenId = mockValues.numbers[5]
+    const withdrawer = mockValues.addresses[8]
+    const exitCaller = mockValues.addresses[3]
+    let dummyERC721
+    let erc721Predicate
+    let exitTokensTx
+
+
+    before(async() => {
+      const contracts = await deployer.deployFreshRootContracts(accounts)
+      dummyERC721 = contracts.dummyERC721
+      erc721Predicate = contracts.erc721Predicate
+      await dummyERC721.mint(tokenId)
+      await dummyERC721.approve(erc721Predicate.address, tokenId)
+      const depositData = abi.encode(['uint256'], [tokenId])
+      await erc721Predicate.lockTokens(accounts[0], withdrawer, dummyERC721.address, depositData)
+    })
+
+    it('Should be able to receive exitTokens tx', async() => {
+      const burnLog = getERC721TransferLog({
+        from: withdrawer,
+        to: mockValues.zeroAddress,
+        tokenId
+      })
+      exitTokensTx = await erc721Predicate.exitTokens(exitCaller, dummyERC721.address, burnLog)
+      should.exist(exitTokensTx)
+    })
+
+    it('Token should be transferred to withdrawer', async() => {
+      const owner = await dummyERC721.ownerOf(tokenId)
+      owner.should.equal(withdrawer)
+    })
+  })
+
   describe('exitTokens with incorrect burn transaction signature', () => {
     const tokenId = mockValues.numbers[5]
     const withdrawer = mockValues.addresses[8]
@@ -276,33 +311,6 @@ contract('ERC721Predicate', (accounts) => {
         tokenId
       })
       await expectRevert(erc721Predicate.exitTokens(withdrawer, dummyERC721.address, burnLog), 'ERC721Predicate: INVALID_SIGNATURE')
-    })
-  })
-
-  describe('exitTokens called by different user', () => {
-    const tokenId = mockValues.numbers[5]
-    const withdrawer = mockValues.addresses[8]
-    const exitCaller = mockValues.addresses[3]
-    let dummyERC721
-    let erc721Predicate
-
-    before(async() => {
-      const contracts = await deployer.deployFreshRootContracts(accounts)
-      dummyERC721 = contracts.dummyERC721
-      erc721Predicate = contracts.erc721Predicate
-      await dummyERC721.mint(tokenId)
-      await dummyERC721.approve(erc721Predicate.address, tokenId)
-      const depositData = abi.encode(['uint256'], [tokenId])
-      await erc721Predicate.lockTokens(accounts[0], withdrawer, dummyERC721.address, depositData)
-    })
-
-    it('Should revert with correct reason', async() => {
-      const burnLog = getERC721TransferLog({
-        from: withdrawer,
-        to: mockValues.zeroAddress,
-        tokenId
-      })
-      await expectRevert(erc721Predicate.exitTokens(exitCaller, dummyERC721.address, burnLog), 'ERC721Predicate: INVALID_SENDER')
     })
   })
 

--- a/test/predicates/ERC721Predicate.test.js
+++ b/test/predicates/ERC721Predicate.test.js
@@ -260,7 +260,6 @@ contract('ERC721Predicate', (accounts) => {
     let erc721Predicate
     let exitTokensTx
 
-
     before(async() => {
       const contracts = await deployer.deployFreshRootContracts(accounts)
       dummyERC721 = contracts.dummyERC721

--- a/test/root/Withdraw.test.js
+++ b/test/root/Withdraw.test.js
@@ -132,28 +132,6 @@ contract('RootChainManager', async(accounts) => {
       root.should.equal(headerData.root)
     })
 
-    // call exit from some account other than depositReceiver
-    it('Should fail: exit using non-deposit receiver account', async() => {
-      const logIndex = 0
-      const data = bufferToHex(
-        rlp.encode([
-          headerNumber,
-          bufferToHex(Buffer.concat(checkpointData.proof)),
-          checkpointData.number,
-          checkpointData.timestamp,
-          bufferToHex(checkpointData.transactionsRoot),
-          bufferToHex(checkpointData.receiptsRoot),
-          bufferToHex(checkpointData.receipt),
-          bufferToHex(rlp.encode(checkpointData.receiptParentNodes)),
-          bufferToHex(checkpointData.path), // branch mask,
-          logIndex
-        ])
-      )
-      // start exit
-      exitTx = await expectRevert(contracts.root.rootChainManager.exit(data,
-        { from: accounts[1] }), 'ERC20Predicate: INVALID_SENDER')
-    })
-
     it('Should fail: exit with a random data receipt', async() => {
       const receipt = await childWeb3.eth.getTransactionReceipt(withdrawTx.receipt.transactionHash)
       const dummyReceipt = getFakeReceiptBytes(receipt, '')
@@ -353,6 +331,302 @@ contract('RootChainManager', async(accounts) => {
     })
   })
 
+  describe('Withdraw ERC20 :: non-deposit account', async() => {
+    const depositAmount = mockValues.amounts[1]
+    let totalDepositedAmount = new BN('0')
+    const withdrawAmount = mockValues.amounts[1]
+    const depositReceiver = accounts[0]
+    const nonDepositAccount = accounts[1]
+    const depositData = abi.encode(['uint256'], [depositAmount.toString()])
+    let contracts
+    let dummyERC20
+    let rootChainManager
+    let accountBalance
+    let contractBalance
+    let transferLog
+    let withdrawTx
+    let checkpointData
+    let headerNumber
+    let exitTx
+
+    before(async() => {
+      contracts = await deployer.deployInitializedContracts(accounts)
+      dummyERC20 = contracts.root.dummyERC20
+      rootChainManager = contracts.root.rootChainManager
+      accountBalance = await dummyERC20.balanceOf(accounts[0])
+      contractBalance = await dummyERC20.balanceOf(contracts.root.erc20Predicate.address)
+    })
+
+    it('Depositor should be able to approve and deposit', async() => {
+      await dummyERC20.approve(contracts.root.erc20Predicate.address, depositAmount)
+      const depositTx = await rootChainManager.depositFor(depositReceiver, dummyERC20.address, depositData)
+      should.exist(depositTx)
+      totalDepositedAmount = totalDepositedAmount.add(depositAmount)
+      const syncTx = await syncState({ tx: depositTx })
+      should.exist(syncTx)
+    })
+
+    it('Second depositor should be able to approve and deposit', async() => {
+      await dummyERC20.mint(depositAmount)
+      await dummyERC20.transfer(accounts[2], depositAmount)
+      await dummyERC20.approve(contracts.root.erc20Predicate.address, mockValues.amounts[2], { from: accounts[2] })
+      const depositTx = await rootChainManager.depositFor(accounts[2], dummyERC20.address, depositData, { from: accounts[2] })
+      should.exist(depositTx)
+      totalDepositedAmount = totalDepositedAmount.add(depositAmount)
+      const syncTx = await syncState({ tx: depositTx })
+      should.exist(syncTx)
+    })
+
+    it('Deposit amount should be deducted from depositor account', async() => {
+      const newAccountBalance = await dummyERC20.balanceOf(accounts[0])
+      newAccountBalance.should.be.a.bignumber.that.equals(
+        accountBalance.sub(depositAmount)
+      )
+      // update account balance
+      accountBalance = newAccountBalance
+    })
+
+    it('Deposit amount should be credited to correct contract', async() => {
+      const newContractBalance = await dummyERC20.balanceOf(contracts.root.erc20Predicate.address)
+      newContractBalance.should.be.a.bignumber.that.equals(
+        contractBalance.add(totalDepositedAmount)
+      )
+
+      // update balance
+      contractBalance = newContractBalance
+    })
+
+    it('Can receive withdraw tx', async() => {
+      withdrawTx = await contracts.child.dummyERC20.withdraw(withdrawAmount, { from: depositReceiver })
+      should.exist(withdrawTx)
+    })
+
+    it('Should emit Transfer log in withdraw tx', () => {
+      const logs = logDecoder.decodeLogs(withdrawTx.receipt.rawLogs)
+      transferLog = logs.find(l => l.event === 'Transfer')
+      should.exist(transferLog)
+    })
+
+    it('Should submit checkpoint', async() => {
+      // submit checkpoint including burn (withdraw) tx
+      checkpointData = await submitCheckpoint(contracts.root.checkpointManager, withdrawTx.receipt)
+      should.exist(checkpointData)
+    })
+
+    it('Should match checkpoint details', async() => {
+      const root = bufferToHex(checkpointData.header.root)
+      should.exist(root)
+
+      // fetch latest header number
+      headerNumber = await contracts.root.checkpointManager.currentCheckpointNumber()
+      headerNumber.should.be.bignumber.gt('0')
+
+      // fetch header block details and validate
+      const headerData = await contracts.root.checkpointManager.headerBlocks(headerNumber)
+      root.should.equal(headerData.root)
+    })
+
+    it('Should fail: exit with a random data receipt', async() => {
+      const receipt = await childWeb3.eth.getTransactionReceipt(withdrawTx.receipt.transactionHash)
+      const dummyReceipt = getFakeReceiptBytes(receipt, '')
+      const logIndex = 0
+      const data = bufferToHex(
+        rlp.encode([
+          headerNumber,
+          bufferToHex(Buffer.concat(checkpointData.proof)),
+          checkpointData.number,
+          checkpointData.timestamp,
+          bufferToHex(checkpointData.transactionsRoot),
+          bufferToHex(checkpointData.receiptsRoot),
+          bufferToHex(dummyReceipt),
+          bufferToHex(rlp.encode(checkpointData.receiptParentNodes)),
+          bufferToHex(checkpointData.path), // branch mask,
+          logIndex
+        ])
+      )
+      // start exit
+      await expectRevert(contracts.root.rootChainManager.exit(data,
+        { from: nonDepositAccount }), 'RootChainManager: INVALID_PROOF')
+    })
+
+    it('Should fail: exit with a fake amount data in receipt', async() => {
+      const receipt = await childWeb3.eth.getTransactionReceipt(
+        withdrawTx.receipt.transactionHash)
+      const dummyReceipt = getFakeReceiptBytes(receipt, mockValues.bytes32[4])
+      const logIndex = 0
+      const data = bufferToHex(
+        rlp.encode([
+          headerNumber,
+          bufferToHex(Buffer.concat(checkpointData.proof)),
+          checkpointData.number,
+          checkpointData.timestamp,
+          bufferToHex(checkpointData.transactionsRoot),
+          bufferToHex(checkpointData.receiptsRoot),
+          bufferToHex(dummyReceipt),
+          bufferToHex(rlp.encode(checkpointData.receiptParentNodes)),
+          bufferToHex(checkpointData.path), // branch mask,
+          logIndex
+        ])
+      )
+      // start exit
+      await expectRevert(contracts.root.rootChainManager.exit(data,
+        { from: nonDepositAccount }), 'revert')
+    })
+
+    it('Should fail to start exit (changed the block number to future block)', async() => {
+      const logIndex = 0
+      const fakeBlockNumber = checkpointData.number + 1
+      const data = bufferToHex(
+        rlp.encode([
+          headerNumber,
+          bufferToHex(Buffer.concat(checkpointData.proof)),
+          fakeBlockNumber,
+          checkpointData.timestamp,
+          bufferToHex(checkpointData.transactionsRoot),
+          bufferToHex(checkpointData.receiptsRoot),
+          bufferToHex(checkpointData.receipt),
+          bufferToHex(rlp.encode(checkpointData.receiptParentNodes)),
+          bufferToHex(checkpointData.path), // branch mask,
+          logIndex
+        ])
+      )
+      // start exit
+      await expectRevert(contracts.root.rootChainManager.exit(data,
+        { from: nonDepositAccount }), 'Leaf index is too big')
+    })
+
+    it('Should fail to start exit (changed the block number with different encoding)', async() => {
+      const logIndex = 0
+      const fakeBlockNumber = pad(checkpointData.number, 64)
+      const data = bufferToHex(
+        rlp.encode([
+          headerNumber,
+          bufferToHex(Buffer.concat(checkpointData.proof)),
+          fakeBlockNumber,
+          checkpointData.timestamp,
+          bufferToHex(checkpointData.transactionsRoot),
+          bufferToHex(checkpointData.receiptsRoot),
+          bufferToHex(checkpointData.receipt),
+          bufferToHex(rlp.encode(checkpointData.receiptParentNodes)),
+          bufferToHex(checkpointData.path), // branch mask,
+          logIndex
+        ])
+      )
+      // start exit
+      await expectRevert.unspecified(contracts.root.rootChainManager.exit(data,
+        { from: nonDepositAccount }))
+    })
+
+    // call exit from some account other than depositReceiver
+    it('Should start exit', async() => {
+      const logIndex = 0
+      const data = bufferToHex(
+        rlp.encode([
+          headerNumber,
+          bufferToHex(Buffer.concat(checkpointData.proof)),
+          checkpointData.number,
+          checkpointData.timestamp,
+          bufferToHex(checkpointData.transactionsRoot),
+          bufferToHex(checkpointData.receiptsRoot),
+          bufferToHex(checkpointData.receipt),
+          bufferToHex(rlp.encode(checkpointData.receiptParentNodes)),
+          bufferToHex(checkpointData.path), // branch mask,
+          logIndex
+        ])
+      )
+
+      // start exit
+      exitTx = await contracts.root.rootChainManager.exit(data, { from: nonDepositAccount })
+      should.exist(exitTx)
+    })
+
+    it('Should fail: exit with a differently encoded amount data in receipt', async() => {
+      const receipt = await childWeb3.eth.getTransactionReceipt(
+        withdrawTx.receipt.transactionHash)
+      const dummyReceipt = getDiffEncodedReceipt(receipt, mockValues.bytes32[4])
+      const logIndex = 0
+      const data = bufferToHex(
+        rlp.encode([
+          headerNumber,
+          bufferToHex(Buffer.concat(checkpointData.proof)),
+          checkpointData.number,
+          checkpointData.timestamp,
+          bufferToHex(checkpointData.transactionsRoot),
+          bufferToHex(checkpointData.receiptsRoot),
+          bufferToHex(dummyReceipt),
+          bufferToHex(rlp.encode(checkpointData.receiptParentNodes)),
+          bufferToHex(checkpointData.path), // branch mask,
+          logIndex
+        ])
+      )
+      // start exit
+      await expectRevert(contracts.root.rootChainManager.exit(data,
+        { from: nonDepositAccount }), 'EXIT_ALREADY_PROCESSED')
+    })
+
+    it('Should fail: start exit again', async() => {
+      const logIndex = 0
+      const data = bufferToHex(
+        rlp.encode([
+          headerNumber,
+          bufferToHex(Buffer.concat(checkpointData.proof)),
+          checkpointData.number,
+          checkpointData.timestamp,
+          bufferToHex(checkpointData.transactionsRoot),
+          bufferToHex(checkpointData.receiptsRoot),
+          bufferToHex(checkpointData.receipt),
+          bufferToHex(rlp.encode(checkpointData.receiptParentNodes)),
+          bufferToHex(checkpointData.path), // branch mask,
+          logIndex
+        ])
+      )
+      // start exit
+      await expectRevert(contracts.root.rootChainManager.exit(data,
+        { from: nonDepositAccount }), 'EXIT_ALREADY_PROCESSED')
+    })
+
+    it('Should fail to start exit again (change the log index to generate same exit hash)', async() => {
+      const logIndex = toHex(Array(64).fill(0).join(''))
+      const data = bufferToHex(
+        rlp.encode([
+          headerNumber,
+          bufferToHex(Buffer.concat(checkpointData.proof)),
+          checkpointData.number,
+          checkpointData.timestamp,
+          bufferToHex(checkpointData.transactionsRoot),
+          bufferToHex(checkpointData.receiptsRoot),
+          bufferToHex(checkpointData.receipt),
+          bufferToHex(rlp.encode(checkpointData.receiptParentNodes)),
+          bufferToHex(checkpointData.path), // branch mask,
+          logIndex
+        ])
+      )
+      // start exit
+      await expectRevert(contracts.root.rootChainManager.exit(data,
+        { from: nonDepositAccount }), 'EXIT_ALREADY_PROCESSED')
+    })
+
+    it('Should emit Transfer log in exit tx', () => {
+      const logs = logDecoder.decodeLogs(exitTx.receipt.rawLogs)
+      const exitTransferLog = logs.find(l => l.event === 'Transfer')
+      should.exist(exitTransferLog)
+    })
+
+    it('Should have more amount in withdrawer account after withdraw', async() => {
+      const newAccountBalance = await dummyERC20.balanceOf(depositReceiver)
+      newAccountBalance.should.be.a.bignumber.that.equals(
+        accountBalance.add(depositAmount)
+      )
+    })
+
+    it('Should have less amount in predicate contract after withdraw', async() => {
+      const newContractBalance = await dummyERC20.balanceOf(contracts.root.erc20Predicate.address)
+      newContractBalance.should.be.a.bignumber.that.equals(
+        contractBalance.sub(withdrawAmount)
+      )
+    })
+  })
+
   describe('Withdraw ERC721', async() => {
     const depositTokenId = mockValues.numbers[4]
     const depositAmount = new BN('1')
@@ -435,28 +709,6 @@ contract('RootChainManager', async(accounts) => {
       // fetch header block details and validate
       const headerData = await contracts.root.checkpointManager.headerBlocks(headerNumber)
       root.should.equal(headerData.root)
-    })
-
-    it('Should fail: exit using a non-deposit receiver account', async() => {
-      const logIndex = 1
-      const data = bufferToHex(
-        rlp.encode([
-          headerNumber,
-          bufferToHex(Buffer.concat(checkpointData.proof)),
-          checkpointData.number,
-          checkpointData.timestamp,
-          bufferToHex(checkpointData.transactionsRoot),
-          bufferToHex(checkpointData.receiptsRoot),
-          bufferToHex(checkpointData.receipt),
-          bufferToHex(rlp.encode(checkpointData.receiptParentNodes)),
-          bufferToHex(checkpointData.path), // branch mask,
-          logIndex
-        ])
-      )
-      // start exit
-      await expectRevert(contracts.root.rootChainManager.exit(data,
-        { from: accounts[1] }), // non deposit receiver
-      'ERC721Predicate: INVALID_SENDER')
     })
 
     it('Should fail: exit with a random data receipt', async() => {
@@ -774,6 +1026,406 @@ contract('RootChainManager', async(accounts) => {
     })
   })
 
+  describe('Withdraw ERC721 :: non-deposit account', async() => {
+    const depositTokenId = mockValues.numbers[4]
+    const depositAmount = new BN('1')
+    const withdrawAmount = new BN('1')
+    const depositReceiver = accounts[0]
+    const nonDepositAccount = accounts[1]
+    const depositData = abi.encode(['uint256'], [depositTokenId.toString()])
+    let contracts
+    let dummyERC721
+    let rootChainManager
+    let accountBalance
+    let contractBalance
+    let transferLog
+    let withdrawTx
+    let checkpointData
+    let headerNumber
+    let exitTx
+
+    before(async() => {
+      contracts = await deployer.deployInitializedContracts(accounts)
+      dummyERC721 = contracts.root.dummyERC721
+      rootChainManager = contracts.root.rootChainManager
+      await dummyERC721.mint(depositTokenId)
+      accountBalance = await dummyERC721.balanceOf(accounts[0])
+      contractBalance = await dummyERC721.balanceOf(contracts.root.erc721Predicate.address)
+    })
+
+    it('Depositor should be able to approve and deposit', async() => {
+      await dummyERC721.approve(contracts.root.erc721Predicate.address, depositTokenId)
+      const depositTx = await rootChainManager.depositFor(depositReceiver, dummyERC721.address, depositData)
+      should.exist(depositTx)
+      const syncTx = await syncState({ tx: depositTx })
+      should.exist(syncTx)
+    })
+
+    it('Deposit amount should be deducted from depositor account', async() => {
+      const newAccountBalance = await dummyERC721.balanceOf(accounts[0])
+      newAccountBalance.should.be.a.bignumber.that.equals(
+        accountBalance.sub(depositAmount)
+      )
+
+      // update account balance
+      accountBalance = newAccountBalance
+    })
+
+    it('Deposit amount should be credited to correct contract', async() => {
+      const newContractBalance = await dummyERC721.balanceOf(contracts.root.erc721Predicate.address)
+      newContractBalance.should.be.a.bignumber.that.equals(
+        contractBalance.add(depositAmount)
+      )
+
+      // update balance
+      contractBalance = newContractBalance
+    })
+
+    it('Can receive withdraw tx', async() => {
+      withdrawTx = await contracts.child.dummyERC721.withdraw(depositTokenId, { from: depositReceiver })
+      should.exist(withdrawTx)
+    })
+
+    it('Should emit Transfer log in withdraw tx', () => {
+      const logs = logDecoder.decodeLogs(withdrawTx.receipt.rawLogs)
+      transferLog = logs.find(l => l.event === 'Transfer')
+      should.exist(transferLog)
+    })
+
+    it('Should submit checkpoint', async() => {
+      // submit checkpoint including burn (withdraw) tx
+      checkpointData = await submitCheckpoint(contracts.root.checkpointManager, withdrawTx.receipt)
+      should.exist(checkpointData)
+    })
+
+    it('Should match checkpoint details', async() => {
+      const root = bufferToHex(checkpointData.header.root)
+      should.exist(root)
+
+      // fetch latest header number
+      headerNumber = await contracts.root.checkpointManager.currentCheckpointNumber()
+      headerNumber.should.be.bignumber.gt('0')
+
+      // fetch header block details and validate
+      const headerData = await contracts.root.checkpointManager.headerBlocks(headerNumber)
+      root.should.equal(headerData.root)
+    })
+
+    it('Should fail: exit with a random data receipt', async() => {
+      const receipt = await childWeb3.eth.getTransactionReceipt(
+        withdrawTx.receipt.transactionHash)
+      const dummyReceipt = getFakeReceiptBytes(receipt, '')
+      const logIndex = 1
+      const data = bufferToHex(
+        rlp.encode([
+          headerNumber,
+          bufferToHex(Buffer.concat(checkpointData.proof)),
+          checkpointData.number,
+          checkpointData.timestamp,
+          bufferToHex(checkpointData.transactionsRoot),
+          bufferToHex(checkpointData.receiptsRoot),
+          bufferToHex(dummyReceipt),
+          bufferToHex(rlp.encode(checkpointData.receiptParentNodes)),
+          bufferToHex(checkpointData.path), // branch mask,
+          logIndex
+        ])
+      )
+      // start exit
+      await expectRevert(contracts.root.rootChainManager.exit(data,
+        { from: nonDepositAccount }), 'revert')
+    })
+
+    it('Should fail: exit with a fake amount data in receipt', async() => {
+      const receipt = await childWeb3.eth.getTransactionReceipt(
+        withdrawTx.receipt.transactionHash)
+      const dummyReceipt = getFakeReceiptBytes(receipt, mockValues.bytes32[4])
+      const logIndex = 1
+      const data = bufferToHex(
+        rlp.encode([
+          headerNumber,
+          bufferToHex(Buffer.concat(checkpointData.proof)),
+          checkpointData.number,
+          checkpointData.timestamp,
+          bufferToHex(checkpointData.transactionsRoot),
+          bufferToHex(checkpointData.receiptsRoot),
+          bufferToHex(dummyReceipt),
+          bufferToHex(rlp.encode(checkpointData.receiptParentNodes)),
+          bufferToHex(checkpointData.path), // branch mask,
+          logIndex
+        ])
+      )
+      // start exit
+      await expectRevert(contracts.root.rootChainManager.exit(data,
+        { from: nonDepositAccount }), 'revert')
+    })
+
+    it('Should fail to start exit (changed the block number)', async() => {
+      const logIndex = 1
+      const fakeBlockNumber = checkpointData.number + 1
+      const data = bufferToHex(
+        rlp.encode([
+          headerNumber,
+          bufferToHex(Buffer.concat(checkpointData.proof)),
+          fakeBlockNumber,
+          checkpointData.timestamp,
+          bufferToHex(checkpointData.transactionsRoot),
+          bufferToHex(checkpointData.receiptsRoot),
+          bufferToHex(checkpointData.receipt),
+          bufferToHex(rlp.encode(checkpointData.receiptParentNodes)),
+          bufferToHex(checkpointData.path), // branch mask,
+          logIndex
+        ])
+      )
+      // start exit
+      await expectRevert(contracts.root.rootChainManager.exit(data,
+        { from: nonDepositAccount }), 'Leaf index is too big')
+    })
+
+    it('Should start exit', async() => {
+      const logIndex = 1
+      const data = bufferToHex(
+        rlp.encode([
+          headerNumber,
+          bufferToHex(Buffer.concat(checkpointData.proof)),
+          checkpointData.number,
+          checkpointData.timestamp,
+          bufferToHex(checkpointData.transactionsRoot),
+          bufferToHex(checkpointData.receiptsRoot),
+          bufferToHex(checkpointData.receipt),
+          bufferToHex(rlp.encode(checkpointData.receiptParentNodes)),
+          bufferToHex(checkpointData.path), // branch mask,
+          logIndex
+        ])
+      )
+      // start exit from non deposit receiver
+      exitTx = await contracts.root.rootChainManager.exit(data, { from: nonDepositAccount })
+      should.exist(exitTx)
+    })
+
+    it('Should fail: start exit again', async() => {
+      const logIndex = 1
+      const data = bufferToHex(
+        rlp.encode([
+          headerNumber,
+          bufferToHex(Buffer.concat(checkpointData.proof)),
+          checkpointData.number,
+          checkpointData.timestamp,
+          bufferToHex(checkpointData.transactionsRoot),
+          bufferToHex(checkpointData.receiptsRoot),
+          bufferToHex(checkpointData.receipt),
+          bufferToHex(rlp.encode(checkpointData.receiptParentNodes)),
+          bufferToHex(checkpointData.path), // branch mask,
+          logIndex
+        ])
+      )
+      // start exit
+      await expectRevert(contracts.root.rootChainManager.exit(data,
+        { from: nonDepositAccount }), 'EXIT_ALREADY_PROCESSED')
+    })
+
+    it('Should fail to start exit again (change the log index to generate same exit hash)', async() => {
+      const logIndex = toHex(Array(63).fill(0).join('') + '1')
+      const data = bufferToHex(
+        rlp.encode([
+          headerNumber,
+          bufferToHex(Buffer.concat(checkpointData.proof)),
+          checkpointData.number,
+          checkpointData.timestamp,
+          bufferToHex(checkpointData.transactionsRoot),
+          bufferToHex(checkpointData.receiptsRoot),
+          bufferToHex(checkpointData.receipt),
+          bufferToHex(rlp.encode(checkpointData.receiptParentNodes)),
+          bufferToHex(checkpointData.path), // branch mask,
+          logIndex
+        ])
+      )
+      // start exit
+      await expectRevert(contracts.root.rootChainManager.exit(data,
+        { from: nonDepositAccount }), 'EXIT_ALREADY_PROCESSED')
+    })
+
+    it('Should emit Transfer log in exit tx', () => {
+      const logs = logDecoder.decodeLogs(exitTx.receipt.rawLogs)
+      const exitTransferLog = logs.find(l => l.event === 'Transfer')
+      should.exist(exitTransferLog)
+    })
+
+    it('Should have more amount in withdrawer account after withdraw', async() => {
+      const newAccountBalance = await dummyERC721.balanceOf(depositReceiver)
+      newAccountBalance.should.be.a.bignumber.that.equals(
+        accountBalance.add(depositAmount)
+      )
+    })
+
+    it('Should have less amount in predicate contract after withdraw', async() => {
+      const newContractBalance = await dummyERC721.balanceOf(contracts.root.erc721Predicate.address)
+      newContractBalance.should.be.a.bignumber.that.equals(
+        contractBalance.sub(withdrawAmount)
+      )
+    })
+  })
+
+  describe('Withdraw batch ERC721', async() => {
+    const tokenId1 = mockValues.numbers[4]
+    const tokenId2 = mockValues.numbers[5]
+    const tokenId3 = mockValues.numbers[8]
+    const user = accounts[0]
+    const depositData = abi.encode(
+      ['uint256[]'],
+      [
+        [tokenId1.toString(), tokenId2.toString(), tokenId3.toString()]
+      ]
+    )
+    let contracts
+    let rootToken
+    let childToken
+    let rootChainManager
+    let checkpointManager
+    let erc721Predicate
+    let withdrawTx
+    let checkpointData
+    let headerNumber
+    let exitTx
+
+    before(async() => {
+      contracts = await deployer.deployInitializedContracts(accounts)
+      rootToken = contracts.root.dummyERC721
+      childToken = contracts.child.dummyERC721
+      rootChainManager = contracts.root.rootChainManager
+      checkpointManager = contracts.root.checkpointManager
+      erc721Predicate = contracts.root.erc721Predicate
+      await rootToken.mint(tokenId1)
+      await rootToken.mint(tokenId2)
+      await rootToken.mint(tokenId3)
+    })
+
+    it('User should own tokens on root chain', async() => {
+      {
+        const owner = await rootToken.ownerOf(tokenId1)
+        owner.should.equal(user)
+      }
+      {
+        const owner = await rootToken.ownerOf(tokenId2)
+        owner.should.equal(user)
+      }
+      {
+        const owner = await rootToken.ownerOf(tokenId3)
+        owner.should.equal(user)
+      }
+    })
+
+    it('Tokens should not exist on child chain', async() => {
+      await expectRevert(childToken.ownerOf(tokenId1), 'ERC721: owner query for nonexistent token')
+      await expectRevert(childToken.ownerOf(tokenId2), 'ERC721: owner query for nonexistent token')
+      await expectRevert(childToken.ownerOf(tokenId3), 'ERC721: owner query for nonexistent token')
+    })
+
+    it('User should be able to approve and deposit', async() => {
+      await rootToken.setApprovalForAll(erc721Predicate.address, true)
+      const depositTx = await rootChainManager.depositFor(user, rootToken.address, depositData)
+      should.exist(depositTx)
+      const syncTx = await syncState({ tx: depositTx })
+      should.exist(syncTx)
+    })
+
+    it('Predicate should own tokens on root chain', async() => {
+      {
+        const owner = await rootToken.ownerOf(tokenId1)
+        owner.should.equal(erc721Predicate.address)
+      }
+      {
+        const owner = await rootToken.ownerOf(tokenId2)
+        owner.should.equal(erc721Predicate.address)
+      }
+      {
+        const owner = await rootToken.ownerOf(tokenId3)
+        owner.should.equal(erc721Predicate.address)
+      }
+    })
+
+    it('User should own tokens on child chain', async() => {
+      {
+        const owner = await childToken.ownerOf(tokenId1)
+        owner.should.equal(user)
+      }
+      {
+        const owner = await childToken.ownerOf(tokenId2)
+        owner.should.equal(user)
+      }
+      {
+        const owner = await childToken.ownerOf(tokenId3)
+        owner.should.equal(user)
+      }
+    })
+
+    it('User should be able to start withdraw', async() => {
+      withdrawTx = await childToken.withdrawBatch([tokenId1, tokenId2, tokenId3])
+      should.exist(withdrawTx)
+    })
+
+    it('Should submit checkpoint', async() => {
+      // submit checkpoint including burn (withdraw) tx
+      checkpointData = await submitCheckpoint(checkpointManager, withdrawTx.receipt)
+      should.exist(checkpointData)
+    })
+
+    it('Should match checkpoint details', async() => {
+      const root = bufferToHex(checkpointData.header.root)
+      should.exist(root)
+
+      // fetch latest header number
+      headerNumber = await checkpointManager.currentCheckpointNumber()
+      headerNumber.should.be.bignumber.gt('0')
+
+      // fetch header block details and validate
+      const headerData = await checkpointManager.headerBlocks(headerNumber)
+      root.should.equal(headerData.root)
+    })
+
+    it('User should be able to exit', async() => {
+      const logIndex = withdrawTx.receipt.rawLogs
+        .findIndex(log => log.topics[0].toLowerCase() === ERC721_WITHDRAW_BATCH_EVENT_SIG.toLowerCase())
+      const data = bufferToHex(
+        rlp.encode([
+          headerNumber,
+          bufferToHex(Buffer.concat(checkpointData.proof)),
+          checkpointData.number,
+          checkpointData.timestamp,
+          bufferToHex(checkpointData.transactionsRoot),
+          bufferToHex(checkpointData.receiptsRoot),
+          bufferToHex(checkpointData.receipt),
+          bufferToHex(rlp.encode(checkpointData.receiptParentNodes)),
+          bufferToHex(checkpointData.path), // branch mask,
+          logIndex
+        ])
+      )
+      // start exit
+      exitTx = await contracts.root.rootChainManager.exit(data, { from: user })
+      should.exist(exitTx)
+    })
+
+    it('User should own tokens on root chain', async() => {
+      {
+        const owner = await rootToken.ownerOf(tokenId1)
+        owner.should.equal(user)
+      }
+      {
+        const owner = await rootToken.ownerOf(tokenId2)
+        owner.should.equal(user)
+      }
+      {
+        const owner = await rootToken.ownerOf(tokenId3)
+        owner.should.equal(user)
+      }
+    })
+
+    it('Tokens should not exist on child chain', async() => {
+      await expectRevert(childToken.ownerOf(tokenId1), 'ERC721: owner query for nonexistent token')
+      await expectRevert(childToken.ownerOf(tokenId2), 'ERC721: owner query for nonexistent token')
+      await expectRevert(childToken.ownerOf(tokenId3), 'ERC721: owner query for nonexistent token')
+    })
+  })
+
   describe('Withdraw single ERC1155', async() => {
     const tokenId = mockValues.numbers[8]
     const depositAmount = mockValues.amounts[1]
@@ -868,27 +1520,6 @@ contract('RootChainManager', async(accounts) => {
       // fetch header block details and validate
       const headerData = await contracts.root.checkpointManager.headerBlocks(headerNumber)
       root.should.equal(headerData.root)
-    })
-
-    it('Should fail: start exit with non-deposit receiver', async() => {
-      const logIndex = 0
-      const data = bufferToHex(
-        rlp.encode([
-          headerNumber,
-          bufferToHex(Buffer.concat(checkpointData.proof)),
-          checkpointData.number,
-          checkpointData.timestamp,
-          bufferToHex(checkpointData.transactionsRoot),
-          bufferToHex(checkpointData.receiptsRoot),
-          bufferToHex(checkpointData.receipt),
-          bufferToHex(rlp.encode(checkpointData.receiptParentNodes)),
-          bufferToHex(checkpointData.path), // branch mask,
-          logIndex
-        ])
-      )
-      // start exit
-      await expectRevert(contracts.root.rootChainManager.exit(data,
-        { from: accounts[1] }), 'ERC1155Predicate: INVALID_SENDER')
     })
 
     it('Should fail: exit with a random data receipt', async() => {
@@ -1045,6 +1676,257 @@ contract('RootChainManager', async(accounts) => {
     })
   })
 
+  describe('Withdraw single ERC1155 :: non-deposit account', async() => {
+    const tokenId = mockValues.numbers[8]
+    const depositAmount = mockValues.amounts[1]
+    const withdrawAmount = mockValues.amounts[1]
+    const depositReceiver = accounts[0]
+    const nonDepositAccount = accounts[1]
+    const depositData = abi.encode(
+      [
+        'uint256[]',
+        'uint256[]',
+        'bytes'
+      ],
+      [
+        [tokenId.toString()],
+        [depositAmount.toString()],
+        ['0x0']
+      ]
+    )
+    let contracts
+    let dummyERC1155
+    let rootChainManager
+    let accountBalance
+    let contractBalance
+    let transferLog
+    let withdrawTx
+    let checkpointData
+    let headerNumber
+    let exitTx
+
+    before(async() => {
+      contracts = await deployer.deployInitializedContracts(accounts)
+      dummyERC1155 = contracts.root.dummyERC1155
+      rootChainManager = contracts.root.rootChainManager
+      const mintAmount = depositAmount.add(mockValues.amounts[2])
+      await dummyERC1155.mint(accounts[0], tokenId, mintAmount)
+      accountBalance = await dummyERC1155.balanceOf(accounts[0], tokenId)
+      contractBalance = await dummyERC1155.balanceOf(contracts.root.erc1155Predicate.address, tokenId)
+    })
+
+    it('Depositor should be able to approve and deposit', async() => {
+      await dummyERC1155.setApprovalForAll(contracts.root.erc1155Predicate.address, true)
+      const depositTx = await rootChainManager.depositFor(depositReceiver, dummyERC1155.address, depositData)
+      should.exist(depositTx)
+      const syncTx = await syncState({ tx: depositTx })
+      should.exist(syncTx)
+    })
+
+    it('Deposit amount should be deducted from depositor account', async() => {
+      const newAccountBalance = await dummyERC1155.balanceOf(accounts[0], tokenId)
+      newAccountBalance.should.be.a.bignumber.that.equals(
+        accountBalance.sub(depositAmount)
+      )
+
+      // update account balance
+      accountBalance = newAccountBalance
+    })
+
+    it('Deposit amount should be credited to correct contract', async() => {
+      const newContractBalance = await dummyERC1155.balanceOf(contracts.root.erc1155Predicate.address, tokenId)
+      newContractBalance.should.be.a.bignumber.that.equals(
+        contractBalance.add(depositAmount)
+      )
+
+      // update balance
+      contractBalance = newContractBalance
+    })
+
+    it('Can receive withdraw tx', async() => {
+      withdrawTx = await contracts.child.dummyERC1155.withdrawSingle(tokenId, withdrawAmount, { from: depositReceiver })
+      should.exist(withdrawTx)
+    })
+
+    it('Should emit Transfer log in withdraw tx', () => {
+      const logs = logDecoder.decodeLogs(withdrawTx.receipt.rawLogs)
+      transferLog = logs.find(l => l.event === 'TransferSingle')
+      should.exist(transferLog)
+    })
+
+    it('Should submit checkpoint', async() => {
+      // submit checkpoint including burn (withdraw) tx
+      checkpointData = await submitCheckpoint(contracts.root.checkpointManager, withdrawTx.receipt)
+      should.exist(checkpointData)
+    })
+
+    it('Should match checkpoint details', async() => {
+      const root = bufferToHex(checkpointData.header.root)
+      should.exist(root)
+
+      // fetch latest header number
+      headerNumber = await contracts.root.checkpointManager.currentCheckpointNumber()
+      headerNumber.should.be.bignumber.gt('0')
+
+      // fetch header block details and validate
+      const headerData = await contracts.root.checkpointManager.headerBlocks(headerNumber)
+      root.should.equal(headerData.root)
+    })
+
+    it('Should fail: exit with a random data receipt', async() => {
+      const receipt = await childWeb3.eth.getTransactionReceipt(withdrawTx.receipt.transactionHash)
+      const dummyReceipt = getFakeReceiptBytes(receipt, '')
+      const logIndex = 0
+      const data = bufferToHex(
+        rlp.encode([
+          headerNumber,
+          bufferToHex(Buffer.concat(checkpointData.proof)),
+          checkpointData.number,
+          checkpointData.timestamp,
+          bufferToHex(checkpointData.transactionsRoot),
+          bufferToHex(checkpointData.receiptsRoot),
+          bufferToHex(dummyReceipt),
+          bufferToHex(rlp.encode(checkpointData.receiptParentNodes)),
+          bufferToHex(checkpointData.path), // branch mask,
+          logIndex
+        ])
+      )
+      // start exit
+      await expectRevert(contracts.root.rootChainManager.exit(data,
+        { from: nonDepositAccount }), 'RootChainManager: INVALID_PROOF')
+    })
+
+    it('Should fail: exit with a fake amount data in receipt', async() => {
+      const receipt = await childWeb3.eth.getTransactionReceipt(
+        withdrawTx.receipt.transactionHash)
+      const dummyReceipt = getFakeReceiptBytes(receipt, mockValues.bytes32[4])
+      const logIndex = 0
+      const data = bufferToHex(
+        rlp.encode([
+          headerNumber,
+          bufferToHex(Buffer.concat(checkpointData.proof)),
+          checkpointData.number,
+          checkpointData.timestamp,
+          bufferToHex(checkpointData.transactionsRoot),
+          bufferToHex(checkpointData.receiptsRoot),
+          bufferToHex(dummyReceipt),
+          bufferToHex(rlp.encode(checkpointData.receiptParentNodes)),
+          bufferToHex(checkpointData.path), // branch mask,
+          logIndex
+        ])
+      )
+      // start exit
+      await expectRevert(contracts.root.rootChainManager.exit(data,
+        { from: nonDepositAccount }), 'revert')
+    })
+
+    it('Should fail to start exit (changed the block number)', async() => {
+      const logIndex = 0
+      const fakeBlockNumber = checkpointData.number + 1
+      const data = bufferToHex(
+        rlp.encode([
+          headerNumber,
+          bufferToHex(Buffer.concat(checkpointData.proof)),
+          fakeBlockNumber,
+          checkpointData.timestamp,
+          bufferToHex(checkpointData.transactionsRoot),
+          bufferToHex(checkpointData.receiptsRoot),
+          bufferToHex(checkpointData.receipt),
+          bufferToHex(rlp.encode(checkpointData.receiptParentNodes)),
+          bufferToHex(checkpointData.path), // branch mask,
+          logIndex
+        ])
+      )
+      // start exit
+      await expectRevert(contracts.root.rootChainManager.exit(data,
+        { from: nonDepositAccount }), 'Leaf index is too big')
+    })
+
+    it('Should start exit', async() => {
+      const logIndex = 0
+      const data = bufferToHex(
+        rlp.encode([
+          headerNumber,
+          bufferToHex(Buffer.concat(checkpointData.proof)),
+          checkpointData.number,
+          checkpointData.timestamp,
+          bufferToHex(checkpointData.transactionsRoot),
+          bufferToHex(checkpointData.receiptsRoot),
+          bufferToHex(checkpointData.receipt),
+          bufferToHex(rlp.encode(checkpointData.receiptParentNodes)),
+          bufferToHex(checkpointData.path), // branch mask,
+          logIndex
+        ])
+      )
+      // start exit
+      exitTx = await contracts.root.rootChainManager.exit(data,
+        { from: nonDepositAccount })
+      should.exist(exitTx)
+    })
+
+    it('Should fail: start exit again', async() => {
+      const logIndex = 0
+      const data = bufferToHex(
+        rlp.encode([
+          headerNumber,
+          bufferToHex(Buffer.concat(checkpointData.proof)),
+          checkpointData.number,
+          checkpointData.timestamp,
+          bufferToHex(checkpointData.transactionsRoot),
+          bufferToHex(checkpointData.receiptsRoot),
+          bufferToHex(checkpointData.receipt),
+          bufferToHex(rlp.encode(checkpointData.receiptParentNodes)),
+          bufferToHex(checkpointData.path), // branch mask,
+          logIndex
+        ])
+      )
+      // start exit
+      await expectRevert(contracts.root.rootChainManager.exit(data,
+        { from: nonDepositAccount }), 'EXIT_ALREADY_PROCESSED')
+    })
+
+    it('Should fail to start exit again (change the log index to generate same exit hash)', async() => {
+      const logIndex = toHex(Array(64).fill(0).join(''))
+      const data = bufferToHex(
+        rlp.encode([
+          headerNumber,
+          bufferToHex(Buffer.concat(checkpointData.proof)),
+          checkpointData.number,
+          checkpointData.timestamp,
+          bufferToHex(checkpointData.transactionsRoot),
+          bufferToHex(checkpointData.receiptsRoot),
+          bufferToHex(checkpointData.receipt),
+          bufferToHex(rlp.encode(checkpointData.receiptParentNodes)),
+          bufferToHex(checkpointData.path), // branch mask,
+          logIndex
+        ])
+      )
+      // start exit
+      await expectRevert(contracts.root.rootChainManager.exit(data,
+        { from: nonDepositAccount }), 'EXIT_ALREADY_PROCESSED')
+    })
+
+    it('Should emit Transfer log in exit tx', () => {
+      const logs = logDecoder.decodeLogs(exitTx.receipt.rawLogs)
+      const exitTransferLog = logs.find(l => l.event === 'TransferSingle')
+      should.exist(exitTransferLog)
+    })
+
+    it('Should have more amount in withdrawer account after withdraw', async() => {
+      const newAccountBalance = await dummyERC1155.balanceOf(depositReceiver, tokenId)
+      newAccountBalance.should.be.a.bignumber.that.equals(
+        accountBalance.add(depositAmount)
+      )
+    })
+
+    it('Should have less amount in predicate contract after withdraw', async() => {
+      const newContractBalance = await dummyERC1155.balanceOf(contracts.root.erc1155Predicate.address, tokenId)
+      newContractBalance.should.be.a.bignumber.that.equals(
+        contractBalance.sub(withdrawAmount)
+      )
+    })
+  })
+
   describe('Withdraw batch ERC1155', async() => {
     let erc1155PredicateAddress
     const withdrawAmountA = mockValues.amounts[2]
@@ -1172,27 +2054,6 @@ contract('RootChainManager', async(accounts) => {
       root.should.equal(headerData.root)
     })
 
-    it('Should fail: start exit with non-deposit receiver', async() => {
-      const logIndex = 0
-      const data = bufferToHex(
-        rlp.encode([
-          headerNumber,
-          bufferToHex(Buffer.concat(checkpointData.proof)),
-          checkpointData.number,
-          checkpointData.timestamp,
-          bufferToHex(checkpointData.transactionsRoot),
-          bufferToHex(checkpointData.receiptsRoot),
-          bufferToHex(checkpointData.receipt),
-          bufferToHex(rlp.encode(checkpointData.receiptParentNodes)),
-          bufferToHex(checkpointData.path), // branch mask,
-          logIndex
-        ])
-      )
-      // start exit
-      await expectRevert(contracts.root.rootChainManager.exit(data,
-        { from: accounts[1] }), 'ERC1155Predicate: INVALID_SENDER')
-    })
-
     it('Should fail: exit with a random data receipt', async() => {
       const receipt = await childWeb3.eth.getTransactionReceipt(withdrawTx.receipt.transactionHash)
       const dummyReceipt = getFakeReceiptBytes(receipt, '')
@@ -1281,6 +2142,255 @@ contract('RootChainManager', async(accounts) => {
       // start exit
       await expectRevert(contracts.root.rootChainManager.exit(data,
         { from: depositReceiver }), 'EXIT_ALREADY_PROCESSED')
+    })
+
+    it('Should emit Transfer log in exit tx', () => {
+      const logs = logDecoder.decodeLogs(exitTx.receipt.rawLogs)
+      const exitTransferLog = logs.find(l => l.event === 'TransferBatch')
+      should.exist(exitTransferLog)
+    })
+
+    it('Should have more amount in withdrawer account after withdraw', async() => {
+      const newAccountBalanceA = await dummyERC1155.balanceOf(depositReceiver, tokenIdA)
+      newAccountBalanceA.should.be.a.bignumber.that.equals(accountBalanceA.add(withdrawAmountA))
+      const newAccountBalanceB = await dummyERC1155.balanceOf(depositReceiver, tokenIdB)
+      newAccountBalanceB.should.be.a.bignumber.that.equals(accountBalanceB.add(withdrawAmountB))
+      const newAccountBalanceC = await dummyERC1155.balanceOf(depositReceiver, tokenIdC)
+      newAccountBalanceC.should.be.a.bignumber.that.equals(accountBalanceC.add(withdrawAmountC))
+    })
+
+    it('Should have less amount in predicate contract after withdraw', async() => {
+      const newContractBalanceA = await dummyERC1155.balanceOf(erc1155PredicateAddress, tokenIdA)
+      newContractBalanceA.should.be.a.bignumber.that.equals(
+        contractBalanceA.sub(withdrawAmountA)
+      )
+      const newContractBalanceB = await dummyERC1155.balanceOf(erc1155PredicateAddress, tokenIdB)
+      newContractBalanceB.should.be.a.bignumber.that.equals(
+        contractBalanceB.sub(withdrawAmountB)
+      )
+      const newContractBalanceC = await dummyERC1155.balanceOf(erc1155PredicateAddress, tokenIdC)
+      newContractBalanceC.should.be.a.bignumber.that.equals(
+        contractBalanceC.sub(withdrawAmountC)
+      )
+    })
+  })
+
+  describe('Withdraw batch ERC1155 :: non-deposit account', async() => {
+    let erc1155PredicateAddress
+    const withdrawAmountA = mockValues.amounts[2]
+    const withdrawAmountB = mockValues.amounts[2]
+    const withdrawAmountC = mockValues.amounts[1]
+    const depositAmountA = withdrawAmountA.add(mockValues.amounts[0])
+    const depositAmountB = withdrawAmountA.add(mockValues.amounts[9])
+    const depositAmountC = withdrawAmountA.add(mockValues.amounts[6])
+    const tokenIdA = mockValues.numbers[4]
+    const tokenIdB = mockValues.numbers[5]
+    const tokenIdC = mockValues.numbers[8]
+    const depositReceiver = accounts[0]
+    const nonDepositAccount = accounts[1]
+    const depositData = constructERC1155DepositData(
+      [tokenIdA, tokenIdB, tokenIdC],
+      [depositAmountA, depositAmountB, depositAmountC]
+    )
+    let contracts
+    let dummyERC1155
+    let rootChainManager
+    let accountBalanceA
+    let accountBalanceB
+    let accountBalanceC
+    let contractBalanceA
+    let contractBalanceB
+    let contractBalanceC
+    let transferBatchLog
+    let withdrawTx
+    let checkpointData
+    let headerNumber
+    let exitTx
+    let logs
+
+    before(async() => {
+      contracts = await deployer.deployInitializedContracts(accounts)
+      dummyERC1155 = contracts.root.dummyERC1155
+      rootChainManager = contracts.root.rootChainManager
+      await dummyERC1155.mint(accounts[0], tokenIdA, depositAmountA)
+      await dummyERC1155.mint(accounts[0], tokenIdB, depositAmountB)
+      await dummyERC1155.mint(accounts[0], tokenIdC, depositAmountC)
+      accountBalanceA = await dummyERC1155.balanceOf(accounts[0], tokenIdA)
+      erc1155PredicateAddress = contracts.root.erc1155Predicate.address
+      contractBalanceA = await dummyERC1155.balanceOf(erc1155PredicateAddress, tokenIdA)
+      accountBalanceB = await dummyERC1155.balanceOf(accounts[0], tokenIdB)
+      contractBalanceB = await dummyERC1155.balanceOf(erc1155PredicateAddress, tokenIdB)
+      accountBalanceC = await dummyERC1155.balanceOf(accounts[0], tokenIdC)
+      contractBalanceC = await dummyERC1155.balanceOf(erc1155PredicateAddress, tokenIdC)
+    })
+
+    it('Depositor should be able to approve and deposit', async() => {
+      await dummyERC1155.setApprovalForAll(contracts.root.erc1155Predicate.address, true)
+      const depositTx = await rootChainManager.depositFor(depositReceiver, dummyERC1155.address, depositData)
+      should.exist(depositTx)
+      const syncTx = await syncState({ tx: depositTx })
+      should.exist(syncTx)
+    })
+
+    it('Deposit amount should be deducted from depositor account', async() => {
+      const newAccountBalanceA = await dummyERC1155.balanceOf(accounts[0], tokenIdA)
+      newAccountBalanceA.should.be.a.bignumber.that.equals(
+        accountBalanceA.sub(depositAmountA)
+      )
+      const newAccountBalanceB = await dummyERC1155.balanceOf(accounts[0], tokenIdB)
+      newAccountBalanceB.should.be.a.bignumber.that.equals(
+        accountBalanceB.sub(depositAmountB)
+      )
+      const newAccountBalanceC = await dummyERC1155.balanceOf(accounts[0], tokenIdC)
+      newAccountBalanceC.should.be.a.bignumber.that.equals(
+        accountBalanceC.sub(depositAmountC)
+      )
+      // update account balance
+      accountBalanceA = newAccountBalanceA
+      accountBalanceB = newAccountBalanceB
+      accountBalanceC = newAccountBalanceC
+    })
+
+    it('Deposit amount should be credited to correct contract', async() => {
+      const newContractBalanceA = await dummyERC1155.balanceOf(erc1155PredicateAddress, tokenIdA)
+      newContractBalanceA.should.be.a.bignumber.that.equals(
+        contractBalanceA.add(depositAmountA)
+      )
+      const newContractBalanceB = await dummyERC1155.balanceOf(erc1155PredicateAddress, tokenIdB)
+      newContractBalanceB.should.be.a.bignumber.that.equals(
+        contractBalanceB.add(depositAmountB)
+      )
+      const newContractBalanceC = await dummyERC1155.balanceOf(erc1155PredicateAddress, tokenIdC)
+      newContractBalanceC.should.be.a.bignumber.that.equals(
+        contractBalanceC.add(depositAmountC)
+      )
+      // update balance
+      contractBalanceA = newContractBalanceA
+      contractBalanceB = newContractBalanceB
+      contractBalanceC = newContractBalanceC
+    })
+
+    it('Can receive withdraw tx', async() => {
+      withdrawTx = await contracts.child.dummyERC1155.withdrawBatch(
+        [tokenIdA, tokenIdB, tokenIdC],
+        [withdrawAmountA, withdrawAmountB, withdrawAmountC],
+        { from: depositReceiver })
+      should.exist(withdrawTx)
+    })
+
+    it('Should emit Transfer log in withdraw tx', () => {
+      logs = logDecoder.decodeLogs(withdrawTx.receipt.rawLogs)
+      transferBatchLog = logs.find(l => l.event === 'TransferBatch')
+      should.exist(transferBatchLog)
+    })
+
+    it('Should submit checkpoint', async() => {
+      // submit checkpoint including burn (withdraw) tx
+      checkpointData = await submitCheckpoint(contracts.root.checkpointManager, withdrawTx.receipt)
+      should.exist(checkpointData)
+    })
+
+    it('Should match checkpoint details', async() => {
+      const root = bufferToHex(checkpointData.header.root)
+      should.exist(root)
+
+      // fetch latest header number
+      headerNumber = await contracts.root.checkpointManager.currentCheckpointNumber()
+      headerNumber.should.be.bignumber.gt('0')
+
+      // fetch header block details and validate
+      const headerData = await contracts.root.checkpointManager.headerBlocks(headerNumber)
+      root.should.equal(headerData.root)
+    })
+
+    it('Should fail: exit with a random data receipt', async() => {
+      const receipt = await childWeb3.eth.getTransactionReceipt(withdrawTx.receipt.transactionHash)
+      const dummyReceipt = getFakeReceiptBytes(receipt, '')
+      const logIndex = 0
+      const data = bufferToHex(
+        rlp.encode([
+          headerNumber,
+          bufferToHex(Buffer.concat(checkpointData.proof)),
+          checkpointData.number,
+          checkpointData.timestamp,
+          bufferToHex(checkpointData.transactionsRoot),
+          bufferToHex(checkpointData.receiptsRoot),
+          bufferToHex(dummyReceipt),
+          bufferToHex(rlp.encode(checkpointData.receiptParentNodes)),
+          bufferToHex(checkpointData.path), // branch mask,
+          logIndex
+        ])
+      )
+      // start exit
+      await expectRevert(contracts.root.rootChainManager.exit(data,
+        { from: nonDepositAccount }), 'RootChainManager: INVALID_PROOF')
+    })
+
+    it('Should fail: exit with a fake amount data in receipt', async() => {
+      const receipt = await childWeb3.eth.getTransactionReceipt(
+        withdrawTx.receipt.transactionHash)
+      const dummyReceipt = getFakeReceiptBytes(receipt, mockValues.bytes32[4])
+      const logIndex = 0
+      const data = bufferToHex(
+        rlp.encode([
+          headerNumber,
+          bufferToHex(Buffer.concat(checkpointData.proof)),
+          checkpointData.number,
+          checkpointData.timestamp,
+          bufferToHex(checkpointData.transactionsRoot),
+          bufferToHex(checkpointData.receiptsRoot),
+          bufferToHex(dummyReceipt),
+          bufferToHex(rlp.encode(checkpointData.receiptParentNodes)),
+          bufferToHex(checkpointData.path), // branch mask,
+          logIndex
+        ])
+      )
+      // start exit
+      await expectRevert(contracts.root.rootChainManager.exit(data,
+        { from: nonDepositAccount }), 'revert')
+    })
+
+    it('Should start exit', async() => {
+      const logIndex = 0
+      const data = bufferToHex(
+        rlp.encode([
+          headerNumber,
+          bufferToHex(Buffer.concat(checkpointData.proof)),
+          checkpointData.number,
+          checkpointData.timestamp,
+          bufferToHex(checkpointData.transactionsRoot),
+          bufferToHex(checkpointData.receiptsRoot),
+          bufferToHex(checkpointData.receipt),
+          bufferToHex(rlp.encode(checkpointData.receiptParentNodes)),
+          bufferToHex(checkpointData.path), // branch mask,
+          logIndex
+        ])
+      )
+      // start exit
+      exitTx = await contracts.root.rootChainManager.exit(data,
+        { from: nonDepositAccount })
+      should.exist(exitTx)
+    })
+
+    it('start exit again', async() => {
+      const logIndex = 0
+      const data = bufferToHex(
+        rlp.encode([
+          headerNumber,
+          bufferToHex(Buffer.concat(checkpointData.proof)),
+          checkpointData.number,
+          checkpointData.timestamp,
+          bufferToHex(checkpointData.transactionsRoot),
+          bufferToHex(checkpointData.receiptsRoot),
+          bufferToHex(checkpointData.receipt),
+          bufferToHex(rlp.encode(checkpointData.receiptParentNodes)),
+          bufferToHex(checkpointData.path), // branch mask,
+          logIndex
+        ])
+      )
+      // start exit
+      await expectRevert(contracts.root.rootChainManager.exit(data,
+        { from: nonDepositAccount }), 'EXIT_ALREADY_PROCESSED')
     })
 
     it('Should emit Transfer log in exit tx', () => {


### PR DESCRIPTION
# Motivation

Nowadays, the process of _exit_ from Matic to Ethereum has a hard UX. Users need to 1) send an exit transaction on Matic, 2) Wait 10-30 minutes, and 3) Send a transaction on Ethereum with the exit proof. Both transactions must be sent/signed by the same user not allowing meta transaction services as GNS station, Biconomy, or a custom relayer to hide them from the end-user.

Removing the check at 3), if the transaction is sent by the _`msgSender()`_, everyone will be allowed to send the exit proof. 

In terms of the UX, the process will be 1) Send an exit transaction on Matic 2) Wait until the full exit process finished forgetting about sending another transaction on Ethereum.

In terms of tools, meta transaction services will be able to provide an _exit from Matic_ service. The user will sign only the Matic transaction and that's all.

The security of removing the check is [covered before](https://github.com/maticnetwork/pos-portal/blob/master/contracts/root/RootChainManager/RootChainManager.sol#L332) calling the `exitTokens` method from the predicate.
