### PR TITLE
Change `{clean,re}map` permission to ADMIN

### DIFF
--- a/contracts/root/RootChainManager/RootChainManager.sol
+++ b/contracts/root/RootChainManager/RootChainManager.sol
@@ -148,7 +148,7 @@ contract RootChainManager is
     function registerPredicate(bytes32 tokenType, address predicateAddress)
         external
         override
-        only(MAPPER_ROLE)
+        only(DEFAULT_ADMIN_ROLE)
     {
         typeToPredicate[tokenType] = predicateAddress;
         emit PredicateRegistered(tokenType, predicateAddress);
@@ -182,7 +182,7 @@ contract RootChainManager is
     function cleanMapToken(
         address rootToken,
         address childToken
-    ) external override only(MAPPER_ROLE) {
+    ) external override only(DEFAULT_ADMIN_ROLE) {
         rootToChildToken[rootToken] = address(0);
         childToRootToken[childToken] = address(0);
         tokenToType[rootToken] = bytes32(0);
@@ -201,7 +201,7 @@ contract RootChainManager is
         address rootToken,
         address childToken,
         bytes32 tokenType
-    ) external override only(MAPPER_ROLE) {
+    ) external override only(DEFAULT_ADMIN_ROLE) {
         // cleanup old mapping
         address oldChildToken = rootToChildToken[rootToken];
         address oldRootToken = childToRootToken[childToken];

--- a/flat/MintableERC1155Predicate.sol
+++ b/flat/MintableERC1155Predicate.sol
@@ -1497,6 +1497,11 @@ contract MintableERC1155Predicate is
             // it'll mint those tokens for this contract and return
             // safely transfer those to withdrawer
             if (tokenBalance < amount) {
+                // @notice We could have done `mint`, but that would require
+                // us implementing `onERC1155Received`, which we avoid intentionally
+                // for sake of only supporting batch deposit.
+                //
+                // Which is why this transfer is wrapped as single element batch minting
                 token.mintBatch(address(this), 
                     makeArrayWithValue(id, 1), 
                     makeArrayWithValue(amount - tokenBalance, 1), 

--- a/flat/RootChainManager.sol
+++ b/flat/RootChainManager.sol
@@ -1795,7 +1795,7 @@ contract RootChainManager is
     function registerPredicate(bytes32 tokenType, address predicateAddress)
         external
         override
-        only(MAPPER_ROLE)
+        only(DEFAULT_ADMIN_ROLE)
     {
         typeToPredicate[tokenType] = predicateAddress;
         emit PredicateRegistered(tokenType, predicateAddress);
@@ -1829,7 +1829,7 @@ contract RootChainManager is
     function cleanMapToken(
         address rootToken,
         address childToken
-    ) external override only(MAPPER_ROLE) {
+    ) external override only(DEFAULT_ADMIN_ROLE) {
         rootToChildToken[rootToken] = address(0);
         childToRootToken[childToken] = address(0);
         tokenToType[rootToken] = bytes32(0);
@@ -1848,7 +1848,7 @@ contract RootChainManager is
         address rootToken,
         address childToken,
         bytes32 tokenType
-    ) external override only(MAPPER_ROLE) {
+    ) external override only(DEFAULT_ADMIN_ROLE) {
         // cleanup old mapping
         address oldChildToken = rootToChildToken[rootToken];
         address oldRootToken = childToRootToken[childToken];


### PR DESCRIPTION
## Why ?

As `remap`﻿ & `cleanMap` are used very infrequently we're granting that access to ADMIN role owners. Please note, it was previously given to MAPPER role.
