### PR TITLE
Ownership check before `StateSync`

### DIFF
--- a/contracts/root/RootChainManager/RootChainManager.sol
+++ b/contracts/root/RootChainManager/RootChainManager.sol
@@ -348,33 +348,6 @@ contract RootChainManager is
         );
     }
 
-    function makeArrayWithAddress(address addr, uint256 size)
-        internal
-        pure
-        returns (address[] memory)
-    {
-        require(addr != address(0), "RootChainManager: Invalid address");
-        require(size > 0, "RootChainManager: Invalid resulting array length");
-
-        address[] memory addresses = new address[](size);
-
-        for (uint256 i = 0; i < size; i++) {
-            addresses[i] = addr;
-        }
-
-        return addresses;
-    }
-
-    function calculateLockedAmounts(uint256[] memory oldBalances, uint256[] memory newBalances) internal pure returns(uint256[] memory){
-        uint256[] memory locked = new uint256[](oldBalances.length);
-
-        for(uint256 i; i < oldBalances.length; i++) {
-            locked[i] = newBalances[i] - oldBalances[i];
-        }
-
-        return locked;
-    }
-
     /**
      * @notice exit tokens by providing proof
      * @dev This function verifies if the transaction actually happened on child chain

--- a/contracts/root/RootChainManager/RootChainManager.sol
+++ b/contracts/root/RootChainManager/RootChainManager.sol
@@ -374,7 +374,7 @@ contract RootChainManager is
                     // check ownership for each of them
                     if(token.ownerOf(tokenIds[i]) == predicateAddress) {
                         // and emit state sync for it
-                        bytes memory syncData = abi.encode(user, rootToken, depositData);
+                        bytes memory syncData = abi.encode(user, rootToken, abi.encode(tokenIds[i]));
                         _stateSender.syncState(
                             childChainManagerAddress,
                             abi.encode(DEPOSIT, syncData)

--- a/contracts/root/RootChainManager/RootChainManager.sol
+++ b/contracts/root/RootChainManager/RootChainManager.sol
@@ -15,6 +15,10 @@ import {AccessControl} from "@openzeppelin/contracts/access/AccessControl.sol";
 import {AccessControlMixin} from "../../common/AccessControlMixin.sol";
 import {ContextMixin} from "../../common/ContextMixin.sol";
 
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {IERC721} from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
+import {IERC1155} from "@openzeppelin/contracts/token/ERC1155/IERC1155.sol";
+
 contract RootChainManager is
     IRootChainManager,
     Initializable,
@@ -303,17 +307,135 @@ contract RootChainManager is
             "RootChainManager: INVALID_USER"
         );
 
-        ITokenPredicate(predicateAddress).lockTokens(
-            _msgSender(),
-            user,
-            rootToken,
-            depositData
-        );
-        bytes memory syncData = abi.encode(user, rootToken, depositData);
-        _stateSender.syncState(
-            childChainManagerAddress,
-            abi.encode(DEPOSIT, syncData)
-        );
+        if(tokenType == 0x8ae85d849167ff996c04040c44924fd364217285e4cad818292c7ac37c0a345b || tokenType == 0x5ffef61af1560b9aefc0e42aaa0f9464854ab113ab7b8bfab271be94cdb1d053) {
+            uint256 amount = abi.decode(depositData, (uint256));
+            
+            IERC20 token = IERC20(rootToken);
+            uint256 oldBalance = token.balanceOf(predicateAddress);
+            ITokenPredicate(predicateAddress).lockTokens(
+                _msgSender(),
+                user,
+                rootToken,
+                depositData
+            );
+            uint256 newBalance = token.balanceOf(predicateAddress);
+
+            bytes memory syncData = abi.encode(user, rootToken, abi.encode(newBalance - oldBalance));
+            _stateSender.syncState(
+                childChainManagerAddress,
+                abi.encode(DEPOSIT, syncData)
+            );
+        } else if(tokenType == 0x73ad2146b3d3a286642c794379d750360a2d53a3459a11b3e5d6cc900f55f44a || tokenType == 0xd4392723c111fcb98b073fe55873efb447bcd23cd3e49ec9ea2581930cd01ddc) {
+            IERC721 token = IERC721(rootToken);
+            // deposit single
+            if (depositData.length == 32) {
+                uint256 tokenId = abi.decode(depositData, (uint256));
+                
+                ITokenPredicate(predicateAddress).lockTokens(
+                    _msgSender(),
+                    user,
+                    rootToken,
+                    depositData
+                );
+
+                if(token.ownerOf(tokenId) == predicateAddress) {
+                    bytes memory syncData = abi.encode(user, rootToken, depositData);
+                    _stateSender.syncState(
+                        childChainManagerAddress,
+                        abi.encode(DEPOSIT, syncData)
+                    );
+                }
+            // deposit batch
+            } else {
+                uint256[] memory tokenIds = abi.decode(depositData, (uint256[]));
+
+                ITokenPredicate(predicateAddress).lockTokens(
+                    _msgSender(),
+                    user,
+                    rootToken,
+                    depositData
+                );
+
+                for (uint256 i; i < tokenIds.length; i++) {
+
+                    if(token.ownerOf(tokenIds[i]) == predicateAddress) {
+                        bytes memory syncData = abi.encode(user, rootToken, depositData);
+                        _stateSender.syncState(
+                            childChainManagerAddress,
+                            abi.encode(DEPOSIT, syncData)
+                        );
+                    }
+
+                }
+            }
+        } else if(tokenType == 0x973bb64086f173ec8099b7ed3d43da984f4a332e4417a08bc6a286e6402b0586 || tokenType == 0xb62883a28321b19a93c6657bfb8ea4cec51ed05c3ab26ecec680fa0c7efb31b9) {
+            (
+                uint256[] memory ids,
+                uint256[] memory amounts,
+                bytes memory data
+            ) = abi.decode(depositData, (uint256[], uint256[], bytes));
+
+            IERC1155 token = IERC1155(rootToken);
+            address[] memory addrArray = makeArrayWithAddress(predicateAddress, ids.length);
+            uint256[] memory oldBalances = token.balanceOfBatch(addrArray, ids);
+
+            ITokenPredicate(predicateAddress).lockTokens(
+                _msgSender(),
+                user,
+                rootToken,
+                depositData
+            );
+
+            uint256[] memory lockedBalances = calculateLockedAmounts(
+                oldBalances, 
+                token.balanceOfBatch(addrArray, ids));
+            
+            bytes memory syncData = abi.encode(user, rootToken, abi.encode(ids, lockedBalances, data));
+            _stateSender.syncState(
+                childChainManagerAddress,
+                abi.encode(DEPOSIT, syncData)
+            );
+        } else {
+            ITokenPredicate(predicateAddress).lockTokens(
+                _msgSender(),
+                user,
+                rootToken,
+                depositData
+            );
+
+            bytes memory syncData = abi.encode(user, rootToken, depositData);
+            _stateSender.syncState(
+                childChainManagerAddress,
+                abi.encode(DEPOSIT, syncData)
+            );
+        }
+    }
+
+    function makeArrayWithAddress(address addr, uint256 size)
+        internal
+        pure
+        returns (address[] memory)
+    {
+        require(addr != address(0), "RootChainManager: Invalid address");
+        require(size > 0, "RootChainManager: Invalid resulting array length");
+
+        address[] memory addresses = new address[](size);
+
+        for (uint256 i = 0; i < size; i++) {
+            addresses[i] = addr;
+        }
+
+        return addresses;
+    }
+
+    function calculateLockedAmounts(uint256[] memory oldBalances, uint256[] memory newBalances) internal pure returns(uint256[] memory){
+        uint256[] memory locked = new uint256[](oldBalances.length);
+
+        for(uint256 i; i < oldBalances.length; i++) {
+            locked[i] = newBalances[i] - oldBalances[i];
+        }
+
+        return locked;
     }
 
     /**

--- a/contracts/root/RootChainManager/RootChainManager.sol
+++ b/contracts/root/RootChainManager/RootChainManager.sol
@@ -307,10 +307,11 @@ contract RootChainManager is
             "RootChainManager: INVALID_USER"
         );
 
-        if(tokenType == 0x8ae85d849167ff996c04040c44924fd364217285e4cad818292c7ac37c0a345b || tokenType == 0x5ffef61af1560b9aefc0e42aaa0f9464854ab113ab7b8bfab271be94cdb1d053) {
-            uint256 amount = abi.decode(depositData, (uint256));
-            
+        // (Mintable)ERC20
+        if(tokenType == 0x8ae85d849167ff996c04040c44924fd364217285e4cad818292c7ac37c0a345b || 
+            tokenType == 0x5ffef61af1560b9aefc0e42aaa0f9464854ab113ab7b8bfab271be94cdb1d053) {
             IERC20 token = IERC20(rootToken);
+            
             uint256 oldBalance = token.balanceOf(predicateAddress);
             ITokenPredicate(predicateAddress).lockTokens(
                 _msgSender(),
@@ -325,9 +326,15 @@ contract RootChainManager is
                 childChainManagerAddress,
                 abi.encode(DEPOSIT, syncData)
             );
-        } else if(tokenType == 0x73ad2146b3d3a286642c794379d750360a2d53a3459a11b3e5d6cc900f55f44a || tokenType == 0xd4392723c111fcb98b073fe55873efb447bcd23cd3e49ec9ea2581930cd01ddc) {
+
+            return;
+        }
+        
+        // (Mintable)ERC721
+        if(tokenType == 0x73ad2146b3d3a286642c794379d750360a2d53a3459a11b3e5d6cc900f55f44a || 
+            tokenType == 0xd4392723c111fcb98b073fe55873efb447bcd23cd3e49ec9ea2581930cd01ddc) {
             IERC721 token = IERC721(rootToken);
-            // deposit single
+            // Deposit Single
             if (depositData.length == 32) {
                 uint256 tokenId = abi.decode(depositData, (uint256));
                 
@@ -345,7 +352,7 @@ contract RootChainManager is
                         abi.encode(DEPOSIT, syncData)
                     );
                 }
-            // deposit batch
+            // Deposit Batch
             } else {
                 uint256[] memory tokenIds = abi.decode(depositData, (uint256[]));
 
@@ -355,10 +362,18 @@ contract RootChainManager is
                     rootToken,
                     depositData
                 );
+                
+                /**
+                    Can't do batch state sync because any of those tokens
+                    in batch may not yet be owned by respective predicate
+                    & we can't create a dynamic memory array
+                 */
 
                 for (uint256 i; i < tokenIds.length; i++) {
 
+                    // check ownership for each of them
                     if(token.ownerOf(tokenIds[i]) == predicateAddress) {
+                        // and emit state sync for it
                         bytes memory syncData = abi.encode(user, rootToken, depositData);
                         _stateSender.syncState(
                             childChainManagerAddress,
@@ -368,7 +383,13 @@ contract RootChainManager is
 
                 }
             }
-        } else if(tokenType == 0x973bb64086f173ec8099b7ed3d43da984f4a332e4417a08bc6a286e6402b0586 || tokenType == 0xb62883a28321b19a93c6657bfb8ea4cec51ed05c3ab26ecec680fa0c7efb31b9) {
+
+            return;
+        }
+        
+        // (Mintable)ERC1155
+        if(tokenType == 0x973bb64086f173ec8099b7ed3d43da984f4a332e4417a08bc6a286e6402b0586 || 
+            tokenType == 0xb62883a28321b19a93c6657bfb8ea4cec51ed05c3ab26ecec680fa0c7efb31b9) {
             (
                 uint256[] memory ids,
                 uint256[] memory amounts,
@@ -395,20 +416,22 @@ contract RootChainManager is
                 childChainManagerAddress,
                 abi.encode(DEPOSIT, syncData)
             );
-        } else {
-            ITokenPredicate(predicateAddress).lockTokens(
-                _msgSender(),
-                user,
-                rootToken,
-                depositData
-            );
 
-            bytes memory syncData = abi.encode(user, rootToken, depositData);
-            _stateSender.syncState(
-                childChainManagerAddress,
-                abi.encode(DEPOSIT, syncData)
-            );
+            return;
         }
+        
+        ITokenPredicate(predicateAddress).lockTokens(
+            _msgSender(),
+            user,
+            rootToken,
+            depositData
+        );
+
+        bytes memory syncData = abi.encode(user, rootToken, depositData);
+        _stateSender.syncState(
+            childChainManagerAddress,
+            abi.encode(DEPOSIT, syncData)
+        );
     }
 
     function makeArrayWithAddress(address addr, uint256 size)

--- a/contracts/root/TokenPredicates/ERC1155Predicate.sol
+++ b/contracts/root/TokenPredicates/ERC1155Predicate.sol
@@ -88,26 +88,6 @@ contract ERC1155Predicate is ITokenPredicate, ERC1155Receiver, AccessControlMixi
         return locked;
     }
 
-    /**
-     * @notice Lock ERC1155 tokens for deposit, callable only by manager
-     * @param depositor Address who wants to deposit tokens
-     * @param depositReceiver Address (address) who wants to receive tokens on child chain
-     * @param rootToken Token which gets deposited
-     * @param depositData ABI encoded id array and amount array
-     */
-    function lockTokens(
-        address depositor,
-        address depositReceiver,
-        address rootToken,
-        bytes calldata depositData
-    )
-        external
-        override
-        only(MANAGER_ROLE)
-    {
-        this.verifiedLockTokens(depositor, depositReceiver, rootToken, depositData);
-    }
-
     // Affirmative response denotes, `verifiedLockTokens` is to be
     // prioritised over `lockTokens`, for performing token locking
     // with stricter checking, by RootChainManager
@@ -115,17 +95,8 @@ contract ERC1155Predicate is ITokenPredicate, ERC1155Receiver, AccessControlMixi
         return true;
     }
 
-    function verifiedLockTokens(
-        address depositor,
-        address depositReceiver,
-        address rootToken,
-        bytes calldata depositData
-    )
-        external
-        override
-        only(MANAGER_ROLE)
-        returns(bytes memory)
-    {
+    // Internal implementation, to be used by both `lockTokens` & `verifiedLockTokens`
+    function do_lock(address depositor, address depositReceiver, address rootToken, bytes memory depositData) private returns(bytes memory) {
         // forcing batch deposit since supporting both single and batch deposit introduces too much complexity
         (
             uint256[] memory ids,
@@ -156,6 +127,40 @@ contract ERC1155Predicate is ITokenPredicate, ERC1155Receiver, AccessControlMixi
             lockedBalances
         );
         return abi.encode(ids, lockedBalances, data);
+    }
+
+    /**
+     * @notice Lock ERC1155 tokens for deposit, callable only by manager
+     * @param depositor Address who wants to deposit tokens
+     * @param depositReceiver Address (address) who wants to receive tokens on child chain
+     * @param rootToken Token which gets deposited
+     * @param depositData ABI encoded id array and amount array
+     */
+    function lockTokens(
+        address depositor,
+        address depositReceiver,
+        address rootToken,
+        bytes calldata depositData
+    )
+        external
+        override
+        only(MANAGER_ROLE)
+    {
+        do_lock(depositor, depositReceiver, rootToken, depositData);
+    }
+
+    function verifiedLockTokens(
+        address depositor,
+        address depositReceiver,
+        address rootToken,
+        bytes calldata depositData
+    )
+        external
+        override
+        only(MANAGER_ROLE)
+        returns(bytes memory)
+    {
+        return do_lock(depositor, depositReceiver, rootToken, depositData);
     }
 
     /**

--- a/contracts/root/TokenPredicates/ERC1155Predicate.sol
+++ b/contracts/root/TokenPredicates/ERC1155Predicate.sol
@@ -105,35 +105,7 @@ contract ERC1155Predicate is ITokenPredicate, ERC1155Receiver, AccessControlMixi
         override
         only(MANAGER_ROLE)
     {
-        // forcing batch deposit since supporting both single and batch deposit introduces too much complexity
-        (
-            uint256[] memory ids,
-            uint256[] memory amounts,
-            bytes memory data
-        ) = abi.decode(depositData, (uint256[], uint256[], bytes));
-
-        IERC1155 token = IERC1155(rootToken);
-
-        address[] memory addrArray = makeArrayWithAddress(address(this), ids.length);
-        uint256[] memory oldBalances = token.balanceOfBatch(addrArray, ids);
-        token.safeBatchTransferFrom(
-            depositor,
-            address(this),
-            ids,
-            amounts,
-            data
-        );
-        uint256[] memory lockedBalances = calculateLockedAmounts(
-            oldBalances, 
-            token.balanceOfBatch(addrArray, ids));
-
-        emit LockedBatchERC1155(
-            depositor,
-            depositReceiver,
-            rootToken,
-            ids,
-            lockedBalances
-        );
+        this.verifiedLockTokens(depositor, depositReceiver, rootToken, depositData);
     }
 
     function verifiedLockTokens(

--- a/contracts/root/TokenPredicates/ERC1155Predicate.sol
+++ b/contracts/root/TokenPredicates/ERC1155Predicate.sol
@@ -136,6 +136,49 @@ contract ERC1155Predicate is ITokenPredicate, ERC1155Receiver, AccessControlMixi
         );
     }
 
+    function verifiedLockTokens(
+        address depositor,
+        address depositReceiver,
+        address rootToken,
+        bytes calldata depositData
+    )
+        external
+        override
+        only(MANAGER_ROLE)
+        returns(bytes memory)
+    {
+        // forcing batch deposit since supporting both single and batch deposit introduces too much complexity
+        (
+            uint256[] memory ids,
+            uint256[] memory amounts,
+            bytes memory data
+        ) = abi.decode(depositData, (uint256[], uint256[], bytes));
+
+        IERC1155 token = IERC1155(rootToken);
+
+        address[] memory addrArray = makeArrayWithAddress(address(this), ids.length);
+        uint256[] memory oldBalances = token.balanceOfBatch(addrArray, ids);
+        token.safeBatchTransferFrom(
+            depositor,
+            address(this),
+            ids,
+            amounts,
+            data
+        );
+        uint256[] memory lockedBalances = calculateLockedAmounts(
+            oldBalances, 
+            token.balanceOfBatch(addrArray, ids));
+
+        emit LockedBatchERC1155(
+            depositor,
+            depositReceiver,
+            rootToken,
+            ids,
+            lockedBalances
+        );
+        return abi.encode(ids, lockedBalances, data);
+    }
+
     /**
      * @notice Validates log signature, from and to address
      * then sends the correct tokenId, amount to withdrawer

--- a/contracts/root/TokenPredicates/ERC1155Predicate.sol
+++ b/contracts/root/TokenPredicates/ERC1155Predicate.sol
@@ -108,6 +108,13 @@ contract ERC1155Predicate is ITokenPredicate, ERC1155Receiver, AccessControlMixi
         this.verifiedLockTokens(depositor, depositReceiver, rootToken, depositData);
     }
 
+    // Affirmative response denotes, `verifiedLockTokens` is to be
+    // prioritised over `lockTokens`, for performing token locking
+    // with stricter checking, by RootChainManager
+    function isVerifiable() pure public returns (bool) {
+        return true;
+    }
+
     function verifiedLockTokens(
         address depositor,
         address depositReceiver,

--- a/contracts/root/TokenPredicates/ERC1155Predicate.sol
+++ b/contracts/root/TokenPredicates/ERC1155Predicate.sol
@@ -61,6 +61,33 @@ contract ERC1155Predicate is ITokenPredicate, ERC1155Receiver, AccessControlMixi
         return ERC1155Receiver(0).onERC1155BatchReceived.selector;
     }
 
+    function makeArrayWithAddress(address addr, uint256 size)
+        internal
+        pure
+        returns (address[] memory)
+    {
+        require(addr != address(0), "ERC1155Predicate: Invalid address");
+        require(size > 0, "ERC1155Predicate: Invalid resulting array length");
+
+        address[] memory addresses = new address[](size);
+
+        for (uint256 i = 0; i < size; i++) {
+            addresses[i] = addr;
+        }
+
+        return addresses;
+    }
+
+    function calculateLockedAmounts(uint256[] memory oldBalances, uint256[] memory newBalances) internal pure returns(uint256[] memory){
+        uint256[] memory locked = new uint256[](oldBalances.length);
+
+        for(uint256 i; i < oldBalances.length; i++) {
+            locked[i] = newBalances[i] - oldBalances[i];
+        }
+
+        return locked;
+    }
+
     /**
      * @notice Lock ERC1155 tokens for deposit, callable only by manager
      * @param depositor Address who wants to deposit tokens
@@ -84,19 +111,28 @@ contract ERC1155Predicate is ITokenPredicate, ERC1155Receiver, AccessControlMixi
             uint256[] memory amounts,
             bytes memory data
         ) = abi.decode(depositData, (uint256[], uint256[], bytes));
-        emit LockedBatchERC1155(
-            depositor,
-            depositReceiver,
-            rootToken,
-            ids,
-            amounts
-        );
-        IERC1155(rootToken).safeBatchTransferFrom(
+
+        IERC1155 token = IERC1155(rootToken);
+
+        address[] memory addrArray = makeArrayWithAddress(address(this), ids.length);
+        uint256[] memory oldBalances = token.balanceOfBatch(addrArray, ids);
+        token.safeBatchTransferFrom(
             depositor,
             address(this),
             ids,
             amounts,
             data
+        );
+        uint256[] memory lockedBalances = calculateLockedAmounts(
+            oldBalances, 
+            token.balanceOfBatch(addrArray, ids));
+
+        emit LockedBatchERC1155(
+            depositor,
+            depositReceiver,
+            rootToken,
+            ids,
+            lockedBalances
         );
     }
 

--- a/contracts/root/TokenPredicates/ERC20Predicate.sol
+++ b/contracts/root/TokenPredicates/ERC20Predicate.sol
@@ -51,6 +51,13 @@ contract ERC20Predicate is ITokenPredicate, AccessControlMixin, Initializable {
         this.verifiedLockTokens(depositor, depositReceiver, rootToken, depositData);
     }
 
+    // Affirmative response denotes, `verifiedLockTokens` is to be
+    // prioritised over `lockTokens`, for performing token locking
+    // with stricter checking, by RootChainManager
+    function isVerifiable() pure public returns (bool) {
+        return true;
+    }
+
     function verifiedLockTokens(
         address depositor,
         address depositReceiver,

--- a/contracts/root/TokenPredicates/ERC20Predicate.sol
+++ b/contracts/root/TokenPredicates/ERC20Predicate.sol
@@ -49,8 +49,13 @@ contract ERC20Predicate is ITokenPredicate, AccessControlMixin, Initializable {
         only(MANAGER_ROLE)
     {
         uint256 amount = abi.decode(depositData, (uint256));
-        emit LockedERC20(depositor, depositReceiver, rootToken, amount);
-        IERC20(rootToken).safeTransferFrom(depositor, address(this), amount);
+
+        IERC20 token = IERC20(rootToken);
+        uint256 oldBalance = token.balanceOf(address(this));
+        token.safeTransferFrom(depositor, address(this), amount);
+        uint256 newBalance = token.balanceOf(address(this));
+
+        emit LockedERC20(depositor, depositReceiver, rootToken, newBalance - oldBalance);
     }
 
     /**

--- a/contracts/root/TokenPredicates/ERC20Predicate.sol
+++ b/contracts/root/TokenPredicates/ERC20Predicate.sol
@@ -48,14 +48,7 @@ contract ERC20Predicate is ITokenPredicate, AccessControlMixin, Initializable {
         override
         only(MANAGER_ROLE)
     {
-        uint256 amount = abi.decode(depositData, (uint256));
-
-        IERC20 token = IERC20(rootToken);
-        uint256 oldBalance = token.balanceOf(address(this));
-        token.safeTransferFrom(depositor, address(this), amount);
-        uint256 newBalance = token.balanceOf(address(this));
-
-        emit LockedERC20(depositor, depositReceiver, rootToken, newBalance - oldBalance);
+        this.verifiedLockTokens(depositor, depositReceiver, rootToken, depositData);
     }
 
     function verifiedLockTokens(

--- a/contracts/root/TokenPredicates/ERC20Predicate.sol
+++ b/contracts/root/TokenPredicates/ERC20Predicate.sol
@@ -58,6 +58,29 @@ contract ERC20Predicate is ITokenPredicate, AccessControlMixin, Initializable {
         emit LockedERC20(depositor, depositReceiver, rootToken, newBalance - oldBalance);
     }
 
+    function verifiedLockTokens(
+        address depositor,
+        address depositReceiver,
+        address rootToken,
+        bytes calldata depositData
+    )
+        external
+        override
+        only(MANAGER_ROLE)
+        returns(bytes memory)
+    {
+        uint256 amount = abi.decode(depositData, (uint256));
+
+        IERC20 token = IERC20(rootToken);
+        uint256 oldBalance = token.balanceOf(address(this));
+        token.safeTransferFrom(depositor, address(this), amount);
+        uint256 newBalance = token.balanceOf(address(this));
+        uint256 locked = newBalance - oldBalance;
+
+        emit LockedERC20(depositor, depositReceiver, rootToken, locked);
+        return abi.encode(locked);
+    }
+
     /**
      * @notice Validates log signature, from and to address
      * then sends the correct amount to withdrawer

--- a/contracts/root/TokenPredicates/ERC721Predicate.sol
+++ b/contracts/root/TokenPredicates/ERC721Predicate.sol
@@ -96,15 +96,18 @@ contract ERC721Predicate is ITokenPredicate, AccessControlMixin, Initializable, 
             require(length <= BATCH_LIMIT, "ERC721Predicate: EXCEEDS_BATCH_LIMIT");
 
             IRootERC721 token = IRootERC721(rootToken);
+            uint256[] memory owned = new uint256[](length);
 
             for (uint256 i; i < length; i++) {
                 uint256 tokenId = tokenIds[i];
 
                 token.safeTransferFrom(depositor, address(this), tokenId);
                 if(token.ownerOf(tokenId) == address(this)) {
-                    emit LockedERC721(depositor, depositReceiver, rootToken, tokenId);
+                    owned[i] = tokenId;
                 }
             }
+
+            emit LockedERC721Batch(depositor, depositReceiver, rootToken, owned);
         }
     }
 

--- a/contracts/root/TokenPredicates/ERC721Predicate.sol
+++ b/contracts/root/TokenPredicates/ERC721Predicate.sol
@@ -80,6 +80,13 @@ contract ERC721Predicate is ITokenPredicate, AccessControlMixin, Initializable, 
         this.verifiedLockTokens(depositor, depositReceiver, rootToken, depositData);
     }
 
+    // Affirmative response denotes, `verifiedLockTokens` is to be
+    // prioritised over `lockTokens`, for performing token locking
+    // with stricter checking, by RootChainManager
+    function isVerifiable() pure public returns (bool) {
+        return true;
+    }
+
     function verifiedLockTokens(
         address depositor,
         address depositReceiver,

--- a/contracts/root/TokenPredicates/ERC721Predicate.sol
+++ b/contracts/root/TokenPredicates/ERC721Predicate.sol
@@ -106,6 +106,46 @@ contract ERC721Predicate is ITokenPredicate, AccessControlMixin, Initializable, 
         }
     }
 
+    function verifiedLockTokens(
+        address depositor,
+        address depositReceiver,
+        address rootToken,
+        bytes calldata depositData
+    )
+        external
+        override
+        only(MANAGER_ROLE)
+        returns (bytes memory)
+    {
+        // deposit single
+        if (depositData.length == 32) {
+            uint256 tokenId = abi.decode(depositData, (uint256));
+            
+            IRootERC721 token = IRootERC721(rootToken);
+            token.safeTransferFrom(depositor, address(this), tokenId);
+
+            require(token.ownerOf(tokenId) == address(this), "ERC721Predicate: TOKEN_NOT_LOCKED");
+            emit LockedERC721(depositor, depositReceiver, rootToken, tokenId);
+
+        // deposit batch
+        } else {
+            uint256[] memory tokenIds = abi.decode(depositData, (uint256[]));
+
+            uint256 length = tokenIds.length;
+            require(length <= BATCH_LIMIT, "ERC721Predicate: EXCEEDS_BATCH_LIMIT");
+
+            IRootERC721 token = IRootERC721(rootToken);
+            for (uint256 i; i < length; i++) {
+                uint256 tokenId = tokenIds[i];
+
+                token.safeTransferFrom(depositor, address(this), tokenId);
+                require(token.ownerOf(tokenId) == address(this), "ERC721Predicate: TOKEN_NOT_LOCKED");
+            }
+            emit LockedERC721Batch(depositor, depositReceiver, rootToken, tokenIds);
+        }
+        return depositData;
+    }
+
     /**
      * @notice Validates log signature, from and to address
      * then sends the correct tokenId to withdrawer

--- a/contracts/root/TokenPredicates/ERC721Predicate.sol
+++ b/contracts/root/TokenPredicates/ERC721Predicate.sol
@@ -77,33 +77,7 @@ contract ERC721Predicate is ITokenPredicate, AccessControlMixin, Initializable, 
         override
         only(MANAGER_ROLE)
     {
-        // deposit single
-        if (depositData.length == 32) {
-            uint256 tokenId = abi.decode(depositData, (uint256));
-            
-            IRootERC721 token = IRootERC721(rootToken);
-            token.safeTransferFrom(depositor, address(this), tokenId);
-
-            if(token.ownerOf(tokenId) == address(this)) {
-                emit LockedERC721(depositor, depositReceiver, rootToken, tokenId);
-            }
-
-        // deposit batch
-        } else {
-            uint256[] memory tokenIds = abi.decode(depositData, (uint256[]));
-
-            uint256 length = tokenIds.length;
-            require(length <= BATCH_LIMIT, "ERC721Predicate: EXCEEDS_BATCH_LIMIT");
-
-            IRootERC721 token = IRootERC721(rootToken);
-            for (uint256 i; i < length; i++) {
-                uint256 tokenId = tokenIds[i];
-
-                token.safeTransferFrom(depositor, address(this), tokenId);
-                require(token.ownerOf(tokenId) == address(this), "ERC721Predicate: TOKEN_NOT_LOCKED");
-            }
-            emit LockedERC721Batch(depositor, depositReceiver, rootToken, tokenIds);
-        }
+        this.verifiedLockTokens(depositor, depositReceiver, rootToken, depositData);
     }
 
     function verifiedLockTokens(

--- a/contracts/root/TokenPredicates/ERC721Predicate.sol
+++ b/contracts/root/TokenPredicates/ERC721Predicate.sol
@@ -96,18 +96,13 @@ contract ERC721Predicate is ITokenPredicate, AccessControlMixin, Initializable, 
             require(length <= BATCH_LIMIT, "ERC721Predicate: EXCEEDS_BATCH_LIMIT");
 
             IRootERC721 token = IRootERC721(rootToken);
-            uint256[] memory owned = new uint256[](length);
-
             for (uint256 i; i < length; i++) {
                 uint256 tokenId = tokenIds[i];
 
                 token.safeTransferFrom(depositor, address(this), tokenId);
-                if(token.ownerOf(tokenId) == address(this)) {
-                    owned[i] = tokenId;
-                }
+                require(token.ownerOf(tokenId) == address(this), "ERC721Predicate: TOKEN_NOT_LOCKED");
             }
-
-            emit LockedERC721Batch(depositor, depositReceiver, rootToken, owned);
+            emit LockedERC721Batch(depositor, depositReceiver, rootToken, tokenIds);
         }
     }
 

--- a/contracts/root/TokenPredicates/ERC721Predicate.sol
+++ b/contracts/root/TokenPredicates/ERC721Predicate.sol
@@ -80,17 +80,30 @@ contract ERC721Predicate is ITokenPredicate, AccessControlMixin, Initializable, 
         // deposit single
         if (depositData.length == 32) {
             uint256 tokenId = abi.decode(depositData, (uint256));
-            emit LockedERC721(depositor, depositReceiver, rootToken, tokenId);
-            IRootERC721(rootToken).safeTransferFrom(depositor, address(this), tokenId);
+            
+            IRootERC721 token = IRootERC721(rootToken);
+            token.safeTransferFrom(depositor, address(this), tokenId);
+
+            if(token.ownerOf(tokenId) == address(this)) {
+                emit LockedERC721(depositor, depositReceiver, rootToken, tokenId);
+            }
 
         // deposit batch
         } else {
             uint256[] memory tokenIds = abi.decode(depositData, (uint256[]));
-            emit LockedERC721Batch(depositor, depositReceiver, rootToken, tokenIds);
+
             uint256 length = tokenIds.length;
             require(length <= BATCH_LIMIT, "ERC721Predicate: EXCEEDS_BATCH_LIMIT");
+
+            IRootERC721 token = IRootERC721(rootToken);
+
             for (uint256 i; i < length; i++) {
-                IRootERC721(rootToken).safeTransferFrom(depositor, address(this), tokenIds[i]);
+                uint256 tokenId = tokenIds[i];
+
+                token.safeTransferFrom(depositor, address(this), tokenId);
+                if(token.ownerOf(tokenId) == address(this)) {
+                    emit LockedERC721(depositor, depositReceiver, rootToken, tokenId);
+                }
             }
         }
     }

--- a/contracts/root/TokenPredicates/EtherPredicate.sol
+++ b/contracts/root/TokenPredicates/EtherPredicate.sol
@@ -56,6 +56,13 @@ contract EtherPredicate is ITokenPredicate, AccessControlMixin, Initializable {
         this.verifiedLockTokens(depositor, depositReceiver, rootToken, depositData);
     }
 
+    // Affirmative response denotes, `verifiedLockTokens` is to be
+    // prioritised over `lockTokens`, for performing token locking
+    // with stricter checking, by RootChainManager
+    function isVerifiable() pure public returns (bool) {
+        return true;
+    }
+
     function verifiedLockTokens(
         address depositor,
         address depositReceiver,

--- a/contracts/root/TokenPredicates/EtherPredicate.sol
+++ b/contracts/root/TokenPredicates/EtherPredicate.sol
@@ -37,6 +37,20 @@ contract EtherPredicate is ITokenPredicate, AccessControlMixin, Initializable {
      */
     receive() external payable only(MANAGER_ROLE) {}
 
+    // Affirmative response denotes, `verifiedLockTokens` is to be
+    // prioritised over `lockTokens`, for performing token locking
+    // with stricter checking, by RootChainManager
+    function isVerifiable() pure public returns (bool) {
+        return true;
+    }
+
+    // Internal implementation, to be used by both `lockTokens` & `verifiedLockTokens`
+    function do_lock(address depositor, address depositReceiver, address, bytes memory depositData) private returns(bytes memory) {
+        uint256 amount = abi.decode(depositData, (uint256));
+        emit LockedEther(depositor, depositReceiver, amount);
+        return depositData;
+    }
+
     /**
      * @notice handle ether lock, callable only by manager
      * @param depositor Address who wants to deposit tokens
@@ -53,20 +67,13 @@ contract EtherPredicate is ITokenPredicate, AccessControlMixin, Initializable {
         override
         only(MANAGER_ROLE)
     {
-        this.verifiedLockTokens(depositor, depositReceiver, rootToken, depositData);
-    }
-
-    // Affirmative response denotes, `verifiedLockTokens` is to be
-    // prioritised over `lockTokens`, for performing token locking
-    // with stricter checking, by RootChainManager
-    function isVerifiable() pure public returns (bool) {
-        return true;
+        do_lock(depositor, depositReceiver, rootToken, depositData);
     }
 
     function verifiedLockTokens(
         address depositor,
         address depositReceiver,
-        address,
+        address rootToken,
         bytes calldata depositData
     )
         external
@@ -74,9 +81,7 @@ contract EtherPredicate is ITokenPredicate, AccessControlMixin, Initializable {
         only(MANAGER_ROLE)
         returns (bytes memory)
     {
-        uint256 amount = abi.decode(depositData, (uint256));
-        emit LockedEther(depositor, depositReceiver, amount);
-        return depositData;
+        return do_lock(depositor, depositReceiver, rootToken, depositData);
     }
 
     /**

--- a/contracts/root/TokenPredicates/EtherPredicate.sol
+++ b/contracts/root/TokenPredicates/EtherPredicate.sol
@@ -46,15 +46,14 @@ contract EtherPredicate is ITokenPredicate, AccessControlMixin, Initializable {
     function lockTokens(
         address depositor,
         address depositReceiver,
-        address,
+        address rootToken,
         bytes calldata depositData
     )
         external
         override
         only(MANAGER_ROLE)
     {
-        uint256 amount = abi.decode(depositData, (uint256));
-        emit LockedEther(depositor, depositReceiver, amount);
+        this.verifiedLockTokens(depositor, depositReceiver, rootToken, depositData);
     }
 
     function verifiedLockTokens(

--- a/contracts/root/TokenPredicates/EtherPredicate.sol
+++ b/contracts/root/TokenPredicates/EtherPredicate.sol
@@ -57,6 +57,22 @@ contract EtherPredicate is ITokenPredicate, AccessControlMixin, Initializable {
         emit LockedEther(depositor, depositReceiver, amount);
     }
 
+    function verifiedLockTokens(
+        address depositor,
+        address depositReceiver,
+        address,
+        bytes calldata depositData
+    )
+        external
+        override
+        only(MANAGER_ROLE)
+        returns (bytes memory)
+    {
+        uint256 amount = abi.decode(depositData, (uint256));
+        emit LockedEther(depositor, depositReceiver, amount);
+        return depositData;
+    }
+
     /**
      * @notice Validates log signature, from and to address
      * then sends the correct amount to withdrawer

--- a/contracts/root/TokenPredicates/ITokenPredicate.sol
+++ b/contracts/root/TokenPredicates/ITokenPredicate.sol
@@ -7,7 +7,7 @@ import {RLPReader} from "../../lib/RLPReader.sol";
 interface ITokenPredicate {
 
     /**
-     * @notice Deposit tokens into pos portal
+     * @notice Deposit tokens into pos portal.
      * @dev When `depositor` deposits tokens into pos portal, tokens get locked into predicate contract.
      * @param depositor Address who wants to deposit tokens
      * @param depositReceiver Address (address) who wants to receive tokens on side chain
@@ -20,6 +20,22 @@ interface ITokenPredicate {
         address rootToken,
         bytes calldata depositData
     ) external;
+
+    /**
+     * @notice Lock tokens in predicate contract & check whether really locked or not. Returns ABI serialised
+     * deposit data which can be used for state sync event emission in RootChainManager i.e. invoker.
+     * @dev When `depositor` deposits tokens into pos portal, tokens get locked into predicate contract.
+     * @param depositor Address who wants to deposit tokens
+     * @param depositReceiver Address (address) who wants to receive tokens on side chain
+     * @param rootToken Token which gets deposited
+     * @param depositData Extra data for deposit (amount for ERC20, token id for ERC721 etc.) [ABI encoded]
+     */
+    function verifiedLockTokens(
+        address depositor,
+        address depositReceiver,
+        address rootToken,
+        bytes calldata depositData
+    ) external returns(bytes memory);
 
     /**
      * @notice Validates and processes exit while withdraw process

--- a/contracts/root/TokenPredicates/MintableERC1155Predicate.sol
+++ b/contracts/root/TokenPredicates/MintableERC1155Predicate.sol
@@ -80,40 +80,15 @@ contract MintableERC1155Predicate is
         return locked;
     }
 
-    /**
-     * @notice Lock ERC1155 tokens for deposit, callable only by manager
-     * @param depositor Address who wants to deposit tokens
-     * @param depositReceiver Address (address) who wants to receive tokens on child chain
-     * @param rootToken Token which gets deposited
-     * @param depositData ABI encoded id array and amount array
-     */
-    function lockTokens(
-        address depositor,
-        address depositReceiver,
-        address rootToken,
-        bytes calldata depositData
-    ) external override only(MANAGER_ROLE) {
-        this.verifiedLockTokens(depositor, depositReceiver, rootToken, depositData);
-    }
-
     // Affirmative response denotes, `verifiedLockTokens` is to be
     // prioritised over `lockTokens`, for performing token locking
     // with stricter checking, by RootChainManager
     function isVerifiable() pure public returns (bool) {
         return true;
     }
-    
-    function verifiedLockTokens(
-        address depositor,
-        address depositReceiver,
-        address rootToken,
-        bytes calldata depositData
-    )
-        external
-        override
-        only(MANAGER_ROLE)
-        returns(bytes memory)
-    {
+
+    // Internal implementation, to be used by both `lockTokens` & `verifiedLockTokens`
+    function do_lock(address depositor, address depositReceiver, address rootToken, bytes memory depositData) private returns(bytes memory) {
         // forcing batch deposit since supporting both single and batch deposit introduces too much complexity
         (
             uint256[] memory ids,
@@ -144,6 +119,36 @@ contract MintableERC1155Predicate is
             lockedBalances
         );
         return abi.encode(ids, lockedBalances, data);
+    }
+
+    /**
+     * @notice Lock ERC1155 tokens for deposit, callable only by manager
+     * @param depositor Address who wants to deposit tokens
+     * @param depositReceiver Address (address) who wants to receive tokens on child chain
+     * @param rootToken Token which gets deposited
+     * @param depositData ABI encoded id array and amount array
+     */
+    function lockTokens(
+        address depositor,
+        address depositReceiver,
+        address rootToken,
+        bytes calldata depositData
+    ) external override only(MANAGER_ROLE) {
+        do_lock(depositor, depositReceiver, rootToken, depositData);
+    }
+    
+    function verifiedLockTokens(
+        address depositor,
+        address depositReceiver,
+        address rootToken,
+        bytes calldata depositData
+    )
+        external
+        override
+        only(MANAGER_ROLE)
+        returns(bytes memory)
+    {
+        return do_lock(depositor, depositReceiver, rootToken, depositData);
     }
     
     // Used when attempting to exit with single token, single amount/ id is converted into

--- a/contracts/root/TokenPredicates/MintableERC1155Predicate.sol
+++ b/contracts/root/TokenPredicates/MintableERC1155Predicate.sol
@@ -93,35 +93,7 @@ contract MintableERC1155Predicate is
         address rootToken,
         bytes calldata depositData
     ) external override only(MANAGER_ROLE) {
-        // forcing batch deposit since supporting both single and batch deposit introduces too much complexity
-        (
-            uint256[] memory ids,
-            uint256[] memory amounts,
-            bytes memory data
-        ) = abi.decode(depositData, (uint256[], uint256[], bytes));
-
-        IMintableERC1155 token = IMintableERC1155(rootToken);
-
-        address[] memory addrArray = makeArrayWithAddress(address(this), ids.length);
-        uint256[] memory oldBalances = token.balanceOfBatch(addrArray, ids);
-        token.safeBatchTransferFrom(
-            depositor,
-            address(this),
-            ids,
-            amounts,
-            data
-        );
-        uint256[] memory lockedBalances = calculateLockedAmounts(
-            oldBalances, 
-            token.balanceOfBatch(addrArray, ids));
-
-        emit LockedBatchMintableERC1155(
-            depositor,
-            depositReceiver,
-            rootToken,
-            ids,
-            lockedBalances
-        );
+        this.verifiedLockTokens(depositor, depositReceiver, rootToken, depositData);
     }
     
     function verifiedLockTokens(

--- a/contracts/root/TokenPredicates/MintableERC1155Predicate.sol
+++ b/contracts/root/TokenPredicates/MintableERC1155Predicate.sol
@@ -95,6 +95,13 @@ contract MintableERC1155Predicate is
     ) external override only(MANAGER_ROLE) {
         this.verifiedLockTokens(depositor, depositReceiver, rootToken, depositData);
     }
+
+    // Affirmative response denotes, `verifiedLockTokens` is to be
+    // prioritised over `lockTokens`, for performing token locking
+    // with stricter checking, by RootChainManager
+    function isVerifiable() pure public returns (bool) {
+        return true;
+    }
     
     function verifiedLockTokens(
         address depositor,

--- a/contracts/root/TokenPredicates/MintableERC1155Predicate.sol
+++ b/contracts/root/TokenPredicates/MintableERC1155Predicate.sol
@@ -70,6 +70,16 @@ contract MintableERC1155Predicate is
         return ERC1155Receiver(0).onERC1155BatchReceived.selector;
     }
 
+    function calculateLockedAmounts(uint256[] memory oldBalances, uint256[] memory newBalances) internal pure returns(uint256[] memory){
+        uint256[] memory locked = new uint256[](oldBalances.length);
+
+        for(uint256 i; i < oldBalances.length; i++) {
+            locked[i] = newBalances[i] - oldBalances[i];
+        }
+
+        return locked;
+    }
+
     /**
      * @notice Lock ERC1155 tokens for deposit, callable only by manager
      * @param depositor Address who wants to deposit tokens
@@ -90,19 +100,27 @@ contract MintableERC1155Predicate is
             bytes memory data
         ) = abi.decode(depositData, (uint256[], uint256[], bytes));
 
-        emit LockedBatchMintableERC1155(
-            depositor,
-            depositReceiver,
-            rootToken,
-            ids,
-            amounts
-        );
-        IMintableERC1155(rootToken).safeBatchTransferFrom(
+        IMintableERC1155 token = IMintableERC1155(rootToken);
+
+        address[] memory addrArray = makeArrayWithAddress(address(this), ids.length);
+        uint256[] memory oldBalances = token.balanceOfBatch(addrArray, ids);
+        token.safeBatchTransferFrom(
             depositor,
             address(this),
             ids,
             amounts,
             data
+        );
+        uint256[] memory lockedBalances = calculateLockedAmounts(
+            oldBalances, 
+            token.balanceOfBatch(addrArray, ids));
+
+        emit LockedBatchMintableERC1155(
+            depositor,
+            depositReceiver,
+            rootToken,
+            ids,
+            lockedBalances
         );
     }
     

--- a/contracts/root/TokenPredicates/MintableERC20Predicate.sol
+++ b/contracts/root/TokenPredicates/MintableERC20Predicate.sol
@@ -51,6 +51,13 @@ contract MintableERC20Predicate is
         this.verifiedLockTokens(depositor, depositReceiver, rootToken, depositData);
     }
 
+    // Affirmative response denotes, `verifiedLockTokens` is to be
+    // prioritised over `lockTokens`, for performing token locking
+    // with stricter checking, by RootChainManager
+    function isVerifiable() pure public returns (bool) {
+        return true;
+    }
+
     function verifiedLockTokens(
         address depositor,
         address depositReceiver,

--- a/contracts/root/TokenPredicates/MintableERC20Predicate.sol
+++ b/contracts/root/TokenPredicates/MintableERC20Predicate.sol
@@ -50,12 +50,12 @@ contract MintableERC20Predicate is
     ) external override only(MANAGER_ROLE) {
         uint256 amount = abi.decode(depositData, (uint256));
 
-        emit LockedMintableERC20(depositor, depositReceiver, rootToken, amount);
-        IMintableERC20(rootToken).transferFrom(
-            depositor,
-            address(this),
-            amount
-        );
+        IMintableERC20 token = IMintableERC20(rootToken);
+        uint256 oldBalance = token.balanceOf(address(this));
+        token.transferFrom(depositor, address(this), amount);
+        uint256 newBalance = token.balanceOf(address(this));
+
+        emit LockedMintableERC20(depositor, depositReceiver, rootToken, newBalance - oldBalance);
     }
 
     /**

--- a/contracts/root/TokenPredicates/MintableERC20Predicate.sol
+++ b/contracts/root/TokenPredicates/MintableERC20Predicate.sol
@@ -58,6 +58,29 @@ contract MintableERC20Predicate is
         emit LockedMintableERC20(depositor, depositReceiver, rootToken, newBalance - oldBalance);
     }
 
+    function verifiedLockTokens(
+        address depositor,
+        address depositReceiver,
+        address rootToken,
+        bytes calldata depositData
+    )
+        external
+        override
+        only(MANAGER_ROLE)
+        returns(bytes memory)
+    {
+        uint256 amount = abi.decode(depositData, (uint256));
+
+        IMintableERC20 token = IMintableERC20(rootToken);
+        uint256 oldBalance = token.balanceOf(address(this));
+        token.transferFrom(depositor, address(this), amount);
+        uint256 newBalance = token.balanceOf(address(this));
+        uint256 locked = newBalance - oldBalance;
+
+        emit LockedMintableERC20(depositor, depositReceiver, rootToken, locked);
+        return abi.encode(locked);
+    }
+
     /**
      * @notice Validates log signature, from and to address
      * then sends the correct amount to withdrawer

--- a/contracts/root/TokenPredicates/MintableERC20Predicate.sol
+++ b/contracts/root/TokenPredicates/MintableERC20Predicate.sol
@@ -48,14 +48,7 @@ contract MintableERC20Predicate is
         address rootToken,
         bytes calldata depositData
     ) external override only(MANAGER_ROLE) {
-        uint256 amount = abi.decode(depositData, (uint256));
-
-        IMintableERC20 token = IMintableERC20(rootToken);
-        uint256 oldBalance = token.balanceOf(address(this));
-        token.transferFrom(depositor, address(this), amount);
-        uint256 newBalance = token.balanceOf(address(this));
-
-        emit LockedMintableERC20(depositor, depositReceiver, rootToken, newBalance - oldBalance);
+        this.verifiedLockTokens(depositor, depositReceiver, rootToken, depositData);
     }
 
     function verifiedLockTokens(

--- a/contracts/root/TokenPredicates/MintableERC721Predicate.sol
+++ b/contracts/root/TokenPredicates/MintableERC721Predicate.sol
@@ -112,6 +112,46 @@ contract MintableERC721Predicate is ITokenPredicate, AccessControlMixin, Initial
 
     }
 
+    function verifiedLockTokens(
+        address depositor,
+        address depositReceiver,
+        address rootToken,
+        bytes calldata depositData
+    )
+        external
+        override
+        only(MANAGER_ROLE)
+        returns (bytes memory)
+    {
+        // deposit single
+        if (depositData.length == 32) {
+            uint256 tokenId = abi.decode(depositData, (uint256));
+            
+            IMintableERC721 token = IMintableERC721(rootToken);
+            token.safeTransferFrom(depositor, address(this), tokenId);
+
+            require(token.ownerOf(tokenId) == address(this), "MintableERC721Predicate: TOKEN_NOT_LOCKED");
+            emit LockedMintableERC721(depositor, depositReceiver, rootToken, tokenId);
+
+        // deposit batch
+        } else {
+            uint256[] memory tokenIds = abi.decode(depositData, (uint256[]));
+
+            uint256 length = tokenIds.length;
+            require(length <= BATCH_LIMIT, "MintableERC721Predicate: EXCEEDS_BATCH_LIMIT");
+
+            IMintableERC721 token = IMintableERC721(rootToken);
+            for (uint256 i; i < length; i++) {
+                uint256 tokenId = tokenIds[i];
+
+                token.safeTransferFrom(depositor, address(this), tokenId);
+                require(token.ownerOf(tokenId) == address(this), "MintableERC721Predicate: TOKEN_NOT_LOCKED");
+            }
+            emit LockedMintableERC721Batch(depositor, depositReceiver, rootToken, tokenIds);
+        }
+        return depositData;
+    }
+
     /**
      * @notice Validates log signature, from and to address
      * then checks if token already exists on root chain

--- a/contracts/root/TokenPredicates/MintableERC721Predicate.sol
+++ b/contracts/root/TokenPredicates/MintableERC721Predicate.sol
@@ -83,6 +83,13 @@ contract MintableERC721Predicate is ITokenPredicate, AccessControlMixin, Initial
         this.verifiedLockTokens(depositor, depositReceiver, rootToken, depositData);
     }
 
+    // Affirmative response denotes, `verifiedLockTokens` is to be
+    // prioritised over `lockTokens`, for performing token locking
+    // with stricter checking, by RootChainManager
+    function isVerifiable() pure public returns (bool) {
+        return true;
+    }
+
     function verifiedLockTokens(
         address depositor,
         address depositReceiver,

--- a/contracts/root/TokenPredicates/MintableERC721Predicate.sol
+++ b/contracts/root/TokenPredicates/MintableERC721Predicate.sol
@@ -101,18 +101,13 @@ contract MintableERC721Predicate is ITokenPredicate, AccessControlMixin, Initial
             require(length <= BATCH_LIMIT, "MintableERC721Predicate: EXCEEDS_BATCH_LIMIT");
 
             IMintableERC721 token = IMintableERC721(rootToken);
-            uint256[] memory owned = new uint256[](length);
-
             for (uint256 i; i < length; i++) {
                 uint256 tokenId = tokenIds[i];
 
                 token.safeTransferFrom(depositor, address(this), tokenId);
-                if(token.ownerOf(tokenId) == address(this)) {
-                    owned[i] = tokenId;
-                }
+                require(token.ownerOf(tokenId) == address(this), "MintableERC721Predicate: TOKEN_NOT_LOCKED");
             }
-
-            emit LockedMintableERC721Batch(depositor, depositReceiver, rootToken, owned);
+            emit LockedMintableERC721Batch(depositor, depositReceiver, rootToken, tokenIds);
         }
 
     }

--- a/contracts/root/TokenPredicates/MintableERC721Predicate.sol
+++ b/contracts/root/TokenPredicates/MintableERC721Predicate.sol
@@ -63,26 +63,6 @@ contract MintableERC721Predicate is ITokenPredicate, AccessControlMixin, Initial
         return IERC721Receiver.onERC721Received.selector;
     }
 
-    /**
-     * @notice Lock ERC721 token(s) for deposit, callable only by manager
-     * @param depositor Address who wants to deposit token
-     * @param depositReceiver Address (address) who wants to receive token on child chain
-     * @param rootToken Token which gets deposited
-     * @param depositData ABI encoded tokenId(s). It's possible to deposit batch of tokens.
-     */
-    function lockTokens(
-        address depositor,
-        address depositReceiver,
-        address rootToken,
-        bytes calldata depositData
-    )
-        external
-        override
-        only(MANAGER_ROLE)
-    {
-        this.verifiedLockTokens(depositor, depositReceiver, rootToken, depositData);
-    }
-
     // Affirmative response denotes, `verifiedLockTokens` is to be
     // prioritised over `lockTokens`, for performing token locking
     // with stricter checking, by RootChainManager
@@ -90,17 +70,8 @@ contract MintableERC721Predicate is ITokenPredicate, AccessControlMixin, Initial
         return true;
     }
 
-    function verifiedLockTokens(
-        address depositor,
-        address depositReceiver,
-        address rootToken,
-        bytes calldata depositData
-    )
-        external
-        override
-        only(MANAGER_ROLE)
-        returns (bytes memory)
-    {
+    // Internal implementation, to be used by both `lockTokens` & `verifiedLockTokens`
+    function do_lock(address depositor, address depositReceiver, address rootToken, bytes memory depositData) private returns(bytes memory) {
         // deposit single
         if (depositData.length == 32) {
             uint256 tokenId = abi.decode(depositData, (uint256));
@@ -128,6 +99,40 @@ contract MintableERC721Predicate is ITokenPredicate, AccessControlMixin, Initial
             emit LockedMintableERC721Batch(depositor, depositReceiver, rootToken, tokenIds);
         }
         return depositData;
+    }
+
+    /**
+     * @notice Lock ERC721 token(s) for deposit, callable only by manager
+     * @param depositor Address who wants to deposit token
+     * @param depositReceiver Address (address) who wants to receive token on child chain
+     * @param rootToken Token which gets deposited
+     * @param depositData ABI encoded tokenId(s). It's possible to deposit batch of tokens.
+     */
+    function lockTokens(
+        address depositor,
+        address depositReceiver,
+        address rootToken,
+        bytes calldata depositData
+    )
+        external
+        override
+        only(MANAGER_ROLE)
+    {
+        do_lock(depositor, depositReceiver, rootToken, depositData);
+    }
+
+    function verifiedLockTokens(
+        address depositor,
+        address depositReceiver,
+        address rootToken,
+        bytes calldata depositData
+    )
+        external
+        override
+        only(MANAGER_ROLE)
+        returns (bytes memory)
+    {
+        return do_lock(depositor, depositReceiver, rootToken, depositData);   
     }
 
     /**

--- a/contracts/root/TokenPredicates/MintableERC721Predicate.sol
+++ b/contracts/root/TokenPredicates/MintableERC721Predicate.sol
@@ -101,15 +101,18 @@ contract MintableERC721Predicate is ITokenPredicate, AccessControlMixin, Initial
             require(length <= BATCH_LIMIT, "MintableERC721Predicate: EXCEEDS_BATCH_LIMIT");
 
             IMintableERC721 token = IMintableERC721(rootToken);
+            uint256[] memory owned = new uint256[](length);
 
             for (uint256 i; i < length; i++) {
                 uint256 tokenId = tokenIds[i];
 
                 token.safeTransferFrom(depositor, address(this), tokenId);
                 if(token.ownerOf(tokenId) == address(this)) {
-                    emit LockedMintableERC721(depositor, depositReceiver, rootToken, tokenId);
+                    owned[i] = tokenId;
                 }
             }
+
+            emit LockedMintableERC721Batch(depositor, depositReceiver, rootToken, owned);
         }
 
     }

--- a/contracts/root/TokenPredicates/MintableERC721Predicate.sol
+++ b/contracts/root/TokenPredicates/MintableERC721Predicate.sol
@@ -86,35 +86,30 @@ contract MintableERC721Predicate is ITokenPredicate, AccessControlMixin, Initial
 
             uint256 tokenId = abi.decode(depositData, (uint256));
 
-            // Emitting event that single token is getting locked in predicate
-            emit LockedMintableERC721(depositor, depositReceiver, rootToken, tokenId);
+            IMintableERC721 token = IMintableERC721(rootToken);
+            token.safeTransferFrom(depositor, address(this), tokenId);
 
-            // Transferring token to this address, which will be
-            // released when attempted to be unlocked
-            IMintableERC721(rootToken).safeTransferFrom(depositor, address(this), tokenId);
+            if(token.ownerOf(tokenId) == address(this)) {
+                emit LockedMintableERC721(depositor, depositReceiver, rootToken, tokenId);
+            }
 
         } else {
             // Locking a set a ERC721 token(s)
-
             uint256[] memory tokenIds = abi.decode(depositData, (uint256[]));
 
-            // Emitting event that a set of ERC721 tokens are getting lockec
-            // in this predicate contract
-            emit LockedMintableERC721Batch(depositor, depositReceiver, rootToken, tokenIds);
-
-            // These many tokens are attempted to be deposited
-            // by user
             uint256 length = tokenIds.length;
             require(length <= BATCH_LIMIT, "MintableERC721Predicate: EXCEEDS_BATCH_LIMIT");
 
-            // Iteratively trying to transfer ERC721 token
-            // to this predicate address
+            IMintableERC721 token = IMintableERC721(rootToken);
+
             for (uint256 i; i < length; i++) {
+                uint256 tokenId = tokenIds[i];
 
-                IMintableERC721(rootToken).safeTransferFrom(depositor, address(this), tokenIds[i]);
-
+                token.safeTransferFrom(depositor, address(this), tokenId);
+                if(token.ownerOf(tokenId) == address(this)) {
+                    emit LockedMintableERC721(depositor, depositReceiver, rootToken, tokenId);
+                }
             }
-
         }
 
     }

--- a/contracts/root/TokenPredicates/MintableERC721Predicate.sol
+++ b/contracts/root/TokenPredicates/MintableERC721Predicate.sol
@@ -80,36 +80,7 @@ contract MintableERC721Predicate is ITokenPredicate, AccessControlMixin, Initial
         override
         only(MANAGER_ROLE)
     {
-
-        // Locking single ERC721 token
-        if (depositData.length == 32) {
-
-            uint256 tokenId = abi.decode(depositData, (uint256));
-
-            IMintableERC721 token = IMintableERC721(rootToken);
-            token.safeTransferFrom(depositor, address(this), tokenId);
-
-            if(token.ownerOf(tokenId) == address(this)) {
-                emit LockedMintableERC721(depositor, depositReceiver, rootToken, tokenId);
-            }
-
-        } else {
-            // Locking a set a ERC721 token(s)
-            uint256[] memory tokenIds = abi.decode(depositData, (uint256[]));
-
-            uint256 length = tokenIds.length;
-            require(length <= BATCH_LIMIT, "MintableERC721Predicate: EXCEEDS_BATCH_LIMIT");
-
-            IMintableERC721 token = IMintableERC721(rootToken);
-            for (uint256 i; i < length; i++) {
-                uint256 tokenId = tokenIds[i];
-
-                token.safeTransferFrom(depositor, address(this), tokenId);
-                require(token.ownerOf(tokenId) == address(this), "MintableERC721Predicate: TOKEN_NOT_LOCKED");
-            }
-            emit LockedMintableERC721Batch(depositor, depositReceiver, rootToken, tokenIds);
-        }
-
+        this.verifiedLockTokens(depositor, depositReceiver, rootToken, depositData);
     }
 
     function verifiedLockTokens(

--- a/flat/ERC1155Predicate.sol
+++ b/flat/ERC1155Predicate.sol
@@ -1347,26 +1347,6 @@ contract ERC1155Predicate is ITokenPredicate, ERC1155Receiver, AccessControlMixi
         return locked;
     }
 
-    /**
-     * @notice Lock ERC1155 tokens for deposit, callable only by manager
-     * @param depositor Address who wants to deposit tokens
-     * @param depositReceiver Address (address) who wants to receive tokens on child chain
-     * @param rootToken Token which gets deposited
-     * @param depositData ABI encoded id array and amount array
-     */
-    function lockTokens(
-        address depositor,
-        address depositReceiver,
-        address rootToken,
-        bytes calldata depositData
-    )
-        external
-        override
-        only(MANAGER_ROLE)
-    {
-        this.verifiedLockTokens(depositor, depositReceiver, rootToken, depositData);
-    }
-
     // Affirmative response denotes, `verifiedLockTokens` is to be
     // prioritised over `lockTokens`, for performing token locking
     // with stricter checking, by RootChainManager
@@ -1374,17 +1354,8 @@ contract ERC1155Predicate is ITokenPredicate, ERC1155Receiver, AccessControlMixi
         return true;
     }
 
-    function verifiedLockTokens(
-        address depositor,
-        address depositReceiver,
-        address rootToken,
-        bytes calldata depositData
-    )
-        external
-        override
-        only(MANAGER_ROLE)
-        returns(bytes memory)
-    {
+    // Internal implementation, to be used by both `lockTokens` & `verifiedLockTokens`
+    function do_lock(address depositor, address depositReceiver, address rootToken, bytes memory depositData) private returns(bytes memory) {
         // forcing batch deposit since supporting both single and batch deposit introduces too much complexity
         (
             uint256[] memory ids,
@@ -1415,6 +1386,40 @@ contract ERC1155Predicate is ITokenPredicate, ERC1155Receiver, AccessControlMixi
             lockedBalances
         );
         return abi.encode(ids, lockedBalances, data);
+    }
+
+    /**
+     * @notice Lock ERC1155 tokens for deposit, callable only by manager
+     * @param depositor Address who wants to deposit tokens
+     * @param depositReceiver Address (address) who wants to receive tokens on child chain
+     * @param rootToken Token which gets deposited
+     * @param depositData ABI encoded id array and amount array
+     */
+    function lockTokens(
+        address depositor,
+        address depositReceiver,
+        address rootToken,
+        bytes calldata depositData
+    )
+        external
+        override
+        only(MANAGER_ROLE)
+    {
+        do_lock(depositor, depositReceiver, rootToken, depositData);
+    }
+
+    function verifiedLockTokens(
+        address depositor,
+        address depositReceiver,
+        address rootToken,
+        bytes calldata depositData
+    )
+        external
+        override
+        only(MANAGER_ROLE)
+        returns(bytes memory)
+    {
+        return do_lock(depositor, depositReceiver, rootToken, depositData);
     }
 
     /**

--- a/flat/ERC1155Predicate.sol
+++ b/flat/ERC1155Predicate.sol
@@ -1364,35 +1364,14 @@ contract ERC1155Predicate is ITokenPredicate, ERC1155Receiver, AccessControlMixi
         override
         only(MANAGER_ROLE)
     {
-        // forcing batch deposit since supporting both single and batch deposit introduces too much complexity
-        (
-            uint256[] memory ids,
-            uint256[] memory amounts,
-            bytes memory data
-        ) = abi.decode(depositData, (uint256[], uint256[], bytes));
+        this.verifiedLockTokens(depositor, depositReceiver, rootToken, depositData);
+    }
 
-        IERC1155 token = IERC1155(rootToken);
-
-        address[] memory addrArray = makeArrayWithAddress(address(this), ids.length);
-        uint256[] memory oldBalances = token.balanceOfBatch(addrArray, ids);
-        token.safeBatchTransferFrom(
-            depositor,
-            address(this),
-            ids,
-            amounts,
-            data
-        );
-        uint256[] memory lockedBalances = calculateLockedAmounts(
-            oldBalances, 
-            token.balanceOfBatch(addrArray, ids));
-
-        emit LockedBatchERC1155(
-            depositor,
-            depositReceiver,
-            rootToken,
-            ids,
-            lockedBalances
-        );
+    // Affirmative response denotes, `verifiedLockTokens` is to be
+    // prioritised over `lockTokens`, for performing token locking
+    // with stricter checking, by RootChainManager
+    function isVerifiable() pure public returns (bool) {
+        return true;
     }
 
     function verifiedLockTokens(

--- a/flat/ERC20Predicate.sol
+++ b/flat/ERC20Predicate.sol
@@ -1344,8 +1344,13 @@ contract ERC20Predicate is ITokenPredicate, AccessControlMixin, Initializable {
         only(MANAGER_ROLE)
     {
         uint256 amount = abi.decode(depositData, (uint256));
-        emit LockedERC20(depositor, depositReceiver, rootToken, amount);
-        IERC20(rootToken).safeTransferFrom(depositor, address(this), amount);
+
+        IERC20 token = IERC20(rootToken);
+        uint256 oldBalance = token.balanceOf(address(this));
+        token.safeTransferFrom(depositor, address(this), amount);
+        uint256 newBalance = token.balanceOf(address(this));
+
+        emit LockedERC20(depositor, depositReceiver, rootToken, newBalance - oldBalance);
     }
 
     /**

--- a/flat/ERC20Predicate.sol
+++ b/flat/ERC20Predicate.sol
@@ -1359,14 +1359,14 @@ contract ERC20Predicate is ITokenPredicate, AccessControlMixin, Initializable {
         override
         only(MANAGER_ROLE)
     {
-        uint256 amount = abi.decode(depositData, (uint256));
+        this.verifiedLockTokens(depositor, depositReceiver, rootToken, depositData);
+    }
 
-        IERC20 token = IERC20(rootToken);
-        uint256 oldBalance = token.balanceOf(address(this));
-        token.safeTransferFrom(depositor, address(this), amount);
-        uint256 newBalance = token.balanceOf(address(this));
-
-        emit LockedERC20(depositor, depositReceiver, rootToken, newBalance - oldBalance);
+    // Affirmative response denotes, `verifiedLockTokens` is to be
+    // prioritised over `lockTokens`, for performing token locking
+    // with stricter checking, by RootChainManager
+    function isVerifiable() pure public returns (bool) {
+        return true;
     }
 
     function verifiedLockTokens(

--- a/flat/ERC20Predicate.sol
+++ b/flat/ERC20Predicate.sol
@@ -1342,6 +1342,27 @@ contract ERC20Predicate is ITokenPredicate, AccessControlMixin, Initializable {
         _setupRole(MANAGER_ROLE, _owner);
     }
 
+    // Affirmative response denotes, `verifiedLockTokens` is to be
+    // prioritised over `lockTokens`, for performing token locking
+    // with stricter checking, by RootChainManager
+    function isVerifiable() pure public returns (bool) {
+        return true;
+    }
+
+    // Internal implementation, to be used by both `lockTokens` & `verifiedLockTokens`
+    function do_lock(address depositor, address depositReceiver, address rootToken, bytes memory depositData) private returns(bytes memory) {
+        uint256 amount = abi.decode(depositData, (uint256));
+
+        IERC20 token = IERC20(rootToken);
+        uint256 oldBalance = token.balanceOf(address(this));
+        token.safeTransferFrom(depositor, address(this), amount);
+        uint256 newBalance = token.balanceOf(address(this));
+        uint256 locked = newBalance - oldBalance;
+
+        emit LockedERC20(depositor, depositReceiver, rootToken, locked);
+        return abi.encode(locked);
+    }
+
     /**
      * @notice Lock ERC20 tokens for deposit, callable only by manager
      * @param depositor Address who wants to deposit tokens
@@ -1359,14 +1380,7 @@ contract ERC20Predicate is ITokenPredicate, AccessControlMixin, Initializable {
         override
         only(MANAGER_ROLE)
     {
-        this.verifiedLockTokens(depositor, depositReceiver, rootToken, depositData);
-    }
-
-    // Affirmative response denotes, `verifiedLockTokens` is to be
-    // prioritised over `lockTokens`, for performing token locking
-    // with stricter checking, by RootChainManager
-    function isVerifiable() pure public returns (bool) {
-        return true;
+        do_lock(depositor, depositReceiver, rootToken, depositData);
     }
 
     function verifiedLockTokens(
@@ -1380,16 +1394,7 @@ contract ERC20Predicate is ITokenPredicate, AccessControlMixin, Initializable {
         only(MANAGER_ROLE)
         returns(bytes memory)
     {
-        uint256 amount = abi.decode(depositData, (uint256));
-
-        IERC20 token = IERC20(rootToken);
-        uint256 oldBalance = token.balanceOf(address(this));
-        token.safeTransferFrom(depositor, address(this), amount);
-        uint256 newBalance = token.balanceOf(address(this));
-        uint256 locked = newBalance - oldBalance;
-
-        emit LockedERC20(depositor, depositReceiver, rootToken, locked);
-        return abi.encode(locked);
+        return do_lock(depositor, depositReceiver, rootToken, depositData);
     }
 
     /**

--- a/flat/ERC721Predicate.sol
+++ b/flat/ERC721Predicate.sol
@@ -1252,17 +1252,30 @@ contract ERC721Predicate is ITokenPredicate, AccessControlMixin, Initializable, 
         // deposit single
         if (depositData.length == 32) {
             uint256 tokenId = abi.decode(depositData, (uint256));
-            emit LockedERC721(depositor, depositReceiver, rootToken, tokenId);
-            IRootERC721(rootToken).safeTransferFrom(depositor, address(this), tokenId);
+            
+            IRootERC721 token = IRootERC721(rootToken);
+            token.safeTransferFrom(depositor, address(this), tokenId);
+
+            if(token.ownerOf(tokenId) == address(this)) {
+                emit LockedERC721(depositor, depositReceiver, rootToken, tokenId);
+            }
 
         // deposit batch
         } else {
             uint256[] memory tokenIds = abi.decode(depositData, (uint256[]));
-            emit LockedERC721Batch(depositor, depositReceiver, rootToken, tokenIds);
+
             uint256 length = tokenIds.length;
             require(length <= BATCH_LIMIT, "ERC721Predicate: EXCEEDS_BATCH_LIMIT");
+
+            IRootERC721 token = IRootERC721(rootToken);
+
             for (uint256 i; i < length; i++) {
-                IRootERC721(rootToken).safeTransferFrom(depositor, address(this), tokenIds[i]);
+                uint256 tokenId = tokenIds[i];
+
+                token.safeTransferFrom(depositor, address(this), tokenId);
+                if(token.ownerOf(tokenId) == address(this)) {
+                    emit LockedERC721(depositor, depositReceiver, rootToken, tokenId);
+                }
             }
         }
     }

--- a/flat/ERC721Predicate.sol
+++ b/flat/ERC721Predicate.sol
@@ -1268,15 +1268,18 @@ contract ERC721Predicate is ITokenPredicate, AccessControlMixin, Initializable, 
             require(length <= BATCH_LIMIT, "ERC721Predicate: EXCEEDS_BATCH_LIMIT");
 
             IRootERC721 token = IRootERC721(rootToken);
+            uint256[] memory owned = new uint256[](length);
 
             for (uint256 i; i < length; i++) {
                 uint256 tokenId = tokenIds[i];
 
                 token.safeTransferFrom(depositor, address(this), tokenId);
                 if(token.ownerOf(tokenId) == address(this)) {
-                    emit LockedERC721(depositor, depositReceiver, rootToken, tokenId);
+                    owned[i] = tokenId;
                 }
             }
+
+            emit LockedERC721Batch(depositor, depositReceiver, rootToken, owned);
         }
     }
 

--- a/flat/ERC721Predicate.sol
+++ b/flat/ERC721Predicate.sol
@@ -1268,18 +1268,13 @@ contract ERC721Predicate is ITokenPredicate, AccessControlMixin, Initializable, 
             require(length <= BATCH_LIMIT, "ERC721Predicate: EXCEEDS_BATCH_LIMIT");
 
             IRootERC721 token = IRootERC721(rootToken);
-            uint256[] memory owned = new uint256[](length);
-
             for (uint256 i; i < length; i++) {
                 uint256 tokenId = tokenIds[i];
 
                 token.safeTransferFrom(depositor, address(this), tokenId);
-                if(token.ownerOf(tokenId) == address(this)) {
-                    owned[i] = tokenId;
-                }
+                require(token.ownerOf(tokenId) == address(this), "ERC721Predicate: TOKEN_NOT_LOCKED");
             }
-
-            emit LockedERC721Batch(depositor, depositReceiver, rootToken, owned);
+            emit LockedERC721Batch(depositor, depositReceiver, rootToken, tokenIds);
         }
     }
 

--- a/flat/ERC721Predicate.sol
+++ b/flat/ERC721Predicate.sol
@@ -1248,26 +1248,6 @@ contract ERC721Predicate is ITokenPredicate, AccessControlMixin, Initializable, 
         return IERC721Receiver.onERC721Received.selector;
     }
 
-    /**
-     * @notice Lock ERC721 tokens for deposit, callable only by manager
-     * @param depositor Address who wants to deposit token
-     * @param depositReceiver Address (address) who wants to receive token on child chain
-     * @param rootToken Token which gets deposited
-     * @param depositData ABI encoded tokenId
-     */
-    function lockTokens(
-        address depositor,
-        address depositReceiver,
-        address rootToken,
-        bytes calldata depositData
-    )
-        external
-        override
-        only(MANAGER_ROLE)
-    {
-        this.verifiedLockTokens(depositor, depositReceiver, rootToken, depositData);
-    }
-
     // Affirmative response denotes, `verifiedLockTokens` is to be
     // prioritised over `lockTokens`, for performing token locking
     // with stricter checking, by RootChainManager
@@ -1275,17 +1255,8 @@ contract ERC721Predicate is ITokenPredicate, AccessControlMixin, Initializable, 
         return true;
     }
 
-    function verifiedLockTokens(
-        address depositor,
-        address depositReceiver,
-        address rootToken,
-        bytes calldata depositData
-    )
-        external
-        override
-        only(MANAGER_ROLE)
-        returns (bytes memory)
-    {
+    // Internal implementation, to be used by both `lockTokens` & `verifiedLockTokens`
+    function do_lock(address depositor, address depositReceiver, address rootToken, bytes memory depositData) private returns(bytes memory) {
         // deposit single
         if (depositData.length == 32) {
             uint256 tokenId = abi.decode(depositData, (uint256));
@@ -1313,6 +1284,40 @@ contract ERC721Predicate is ITokenPredicate, AccessControlMixin, Initializable, 
             emit LockedERC721Batch(depositor, depositReceiver, rootToken, tokenIds);
         }
         return depositData;
+    }
+
+    /**
+     * @notice Lock ERC721 tokens for deposit, callable only by manager
+     * @param depositor Address who wants to deposit token
+     * @param depositReceiver Address (address) who wants to receive token on child chain
+     * @param rootToken Token which gets deposited
+     * @param depositData ABI encoded tokenId
+     */
+    function lockTokens(
+        address depositor,
+        address depositReceiver,
+        address rootToken,
+        bytes calldata depositData
+    )
+        external
+        override
+        only(MANAGER_ROLE)
+    {
+        do_lock(depositor, depositReceiver, rootToken, depositData);
+    }
+
+    function verifiedLockTokens(
+        address depositor,
+        address depositReceiver,
+        address rootToken,
+        bytes calldata depositData
+    )
+        external
+        override
+        only(MANAGER_ROLE)
+        returns (bytes memory)
+    {
+        return do_lock(depositor, depositReceiver, rootToken, depositData);
     }
 
     /**

--- a/flat/ERC721Predicate.sol
+++ b/flat/ERC721Predicate.sol
@@ -1265,33 +1265,14 @@ contract ERC721Predicate is ITokenPredicate, AccessControlMixin, Initializable, 
         override
         only(MANAGER_ROLE)
     {
-        // deposit single
-        if (depositData.length == 32) {
-            uint256 tokenId = abi.decode(depositData, (uint256));
-            
-            IRootERC721 token = IRootERC721(rootToken);
-            token.safeTransferFrom(depositor, address(this), tokenId);
+        this.verifiedLockTokens(depositor, depositReceiver, rootToken, depositData);
+    }
 
-            if(token.ownerOf(tokenId) == address(this)) {
-                emit LockedERC721(depositor, depositReceiver, rootToken, tokenId);
-            }
-
-        // deposit batch
-        } else {
-            uint256[] memory tokenIds = abi.decode(depositData, (uint256[]));
-
-            uint256 length = tokenIds.length;
-            require(length <= BATCH_LIMIT, "ERC721Predicate: EXCEEDS_BATCH_LIMIT");
-
-            IRootERC721 token = IRootERC721(rootToken);
-            for (uint256 i; i < length; i++) {
-                uint256 tokenId = tokenIds[i];
-
-                token.safeTransferFrom(depositor, address(this), tokenId);
-                require(token.ownerOf(tokenId) == address(this), "ERC721Predicate: TOKEN_NOT_LOCKED");
-            }
-            emit LockedERC721Batch(depositor, depositReceiver, rootToken, tokenIds);
-        }
+    // Affirmative response denotes, `verifiedLockTokens` is to be
+    // prioritised over `lockTokens`, for performing token locking
+    // with stricter checking, by RootChainManager
+    function isVerifiable() pure public returns (bool) {
+        return true;
     }
 
     function verifiedLockTokens(

--- a/flat/EtherPredicate.sol
+++ b/flat/EtherPredicate.sol
@@ -930,7 +930,7 @@ pragma solidity 0.6.6;
 interface ITokenPredicate {
 
     /**
-     * @notice Deposit tokens into pos portal
+     * @notice Deposit tokens into pos portal.
      * @dev When `depositor` deposits tokens into pos portal, tokens get locked into predicate contract.
      * @param depositor Address who wants to deposit tokens
      * @param depositReceiver Address (address) who wants to receive tokens on side chain
@@ -943,6 +943,22 @@ interface ITokenPredicate {
         address rootToken,
         bytes calldata depositData
     ) external;
+
+    /**
+     * @notice Lock tokens in predicate contract & check whether really locked or not. Returns ABI serialised
+     * deposit data which can be used for state sync event emission in RootChainManager i.e. invoker.
+     * @dev When `depositor` deposits tokens into pos portal, tokens get locked into predicate contract.
+     * @param depositor Address who wants to deposit tokens
+     * @param depositReceiver Address (address) who wants to receive tokens on side chain
+     * @param rootToken Token which gets deposited
+     * @param depositData Extra data for deposit (amount for ERC20, token id for ERC721 etc.) [ABI encoded]
+     */
+    function verifiedLockTokens(
+        address depositor,
+        address depositReceiver,
+        address rootToken,
+        bytes calldata depositData
+    ) external returns(bytes memory);
 
     /**
      * @notice Validates and processes exit while withdraw process
@@ -1031,6 +1047,22 @@ contract EtherPredicate is ITokenPredicate, AccessControlMixin, Initializable {
     {
         uint256 amount = abi.decode(depositData, (uint256));
         emit LockedEther(depositor, depositReceiver, amount);
+    }
+
+    function verifiedLockTokens(
+        address depositor,
+        address depositReceiver,
+        address,
+        bytes calldata depositData
+    )
+        external
+        override
+        only(MANAGER_ROLE)
+        returns (bytes memory)
+    {
+        uint256 amount = abi.decode(depositData, (uint256));
+        emit LockedEther(depositor, depositReceiver, amount);
+        return depositData;
     }
 
     /**

--- a/flat/EtherPredicate.sol
+++ b/flat/EtherPredicate.sol
@@ -1038,15 +1038,21 @@ contract EtherPredicate is ITokenPredicate, AccessControlMixin, Initializable {
     function lockTokens(
         address depositor,
         address depositReceiver,
-        address,
+        address rootToken,
         bytes calldata depositData
     )
         external
         override
         only(MANAGER_ROLE)
     {
-        uint256 amount = abi.decode(depositData, (uint256));
-        emit LockedEther(depositor, depositReceiver, amount);
+        this.verifiedLockTokens(depositor, depositReceiver, rootToken, depositData);
+    }
+
+    // Affirmative response denotes, `verifiedLockTokens` is to be
+    // prioritised over `lockTokens`, for performing token locking
+    // with stricter checking, by RootChainManager
+    function isVerifiable() pure public returns (bool) {
+        return true;
     }
 
     function verifiedLockTokens(

--- a/flat/MintableERC1155Predicate.sol
+++ b/flat/MintableERC1155Predicate.sol
@@ -1369,40 +1369,15 @@ contract MintableERC1155Predicate is
         return locked;
     }
 
-    /**
-     * @notice Lock ERC1155 tokens for deposit, callable only by manager
-     * @param depositor Address who wants to deposit tokens
-     * @param depositReceiver Address (address) who wants to receive tokens on child chain
-     * @param rootToken Token which gets deposited
-     * @param depositData ABI encoded id array and amount array
-     */
-    function lockTokens(
-        address depositor,
-        address depositReceiver,
-        address rootToken,
-        bytes calldata depositData
-    ) external override only(MANAGER_ROLE) {
-        this.verifiedLockTokens(depositor, depositReceiver, rootToken, depositData);
-    }
-
     // Affirmative response denotes, `verifiedLockTokens` is to be
     // prioritised over `lockTokens`, for performing token locking
     // with stricter checking, by RootChainManager
     function isVerifiable() pure public returns (bool) {
         return true;
     }
-    
-    function verifiedLockTokens(
-        address depositor,
-        address depositReceiver,
-        address rootToken,
-        bytes calldata depositData
-    )
-        external
-        override
-        only(MANAGER_ROLE)
-        returns(bytes memory)
-    {
+
+    // Internal implementation, to be used by both `lockTokens` & `verifiedLockTokens`
+    function do_lock(address depositor, address depositReceiver, address rootToken, bytes memory depositData) private returns(bytes memory) {
         // forcing batch deposit since supporting both single and batch deposit introduces too much complexity
         (
             uint256[] memory ids,
@@ -1433,6 +1408,36 @@ contract MintableERC1155Predicate is
             lockedBalances
         );
         return abi.encode(ids, lockedBalances, data);
+    }
+
+    /**
+     * @notice Lock ERC1155 tokens for deposit, callable only by manager
+     * @param depositor Address who wants to deposit tokens
+     * @param depositReceiver Address (address) who wants to receive tokens on child chain
+     * @param rootToken Token which gets deposited
+     * @param depositData ABI encoded id array and amount array
+     */
+    function lockTokens(
+        address depositor,
+        address depositReceiver,
+        address rootToken,
+        bytes calldata depositData
+    ) external override only(MANAGER_ROLE) {
+        do_lock(depositor, depositReceiver, rootToken, depositData);
+    }
+    
+    function verifiedLockTokens(
+        address depositor,
+        address depositReceiver,
+        address rootToken,
+        bytes calldata depositData
+    )
+        external
+        override
+        only(MANAGER_ROLE)
+        returns(bytes memory)
+    {
+        return do_lock(depositor, depositReceiver, rootToken, depositData);
     }
     
     // Used when attempting to exit with single token, single amount/ id is converted into

--- a/flat/MintableERC1155Predicate.sol
+++ b/flat/MintableERC1155Predicate.sol
@@ -1227,7 +1227,7 @@ pragma solidity 0.6.6;
 interface ITokenPredicate {
 
     /**
-     * @notice Deposit tokens into pos portal
+     * @notice Deposit tokens into pos portal.
      * @dev When `depositor` deposits tokens into pos portal, tokens get locked into predicate contract.
      * @param depositor Address who wants to deposit tokens
      * @param depositReceiver Address (address) who wants to receive tokens on side chain
@@ -1240,6 +1240,22 @@ interface ITokenPredicate {
         address rootToken,
         bytes calldata depositData
     ) external;
+
+    /**
+     * @notice Lock tokens in predicate contract & check whether really locked or not. Returns ABI serialised
+     * deposit data which can be used for state sync event emission in RootChainManager i.e. invoker.
+     * @dev When `depositor` deposits tokens into pos portal, tokens get locked into predicate contract.
+     * @param depositor Address who wants to deposit tokens
+     * @param depositReceiver Address (address) who wants to receive tokens on side chain
+     * @param rootToken Token which gets deposited
+     * @param depositData Extra data for deposit (amount for ERC20, token id for ERC721 etc.) [ABI encoded]
+     */
+    function verifiedLockTokens(
+        address depositor,
+        address depositReceiver,
+        address rootToken,
+        bytes calldata depositData
+    ) external returns(bytes memory);
 
     /**
      * @notice Validates and processes exit while withdraw process
@@ -1395,6 +1411,49 @@ contract MintableERC1155Predicate is
             ids,
             lockedBalances
         );
+    }
+    
+    function verifiedLockTokens(
+        address depositor,
+        address depositReceiver,
+        address rootToken,
+        bytes calldata depositData
+    )
+        external
+        override
+        only(MANAGER_ROLE)
+        returns(bytes memory)
+    {
+        // forcing batch deposit since supporting both single and batch deposit introduces too much complexity
+        (
+            uint256[] memory ids,
+            uint256[] memory amounts,
+            bytes memory data
+        ) = abi.decode(depositData, (uint256[], uint256[], bytes));
+
+        IMintableERC1155 token = IMintableERC1155(rootToken);
+
+        address[] memory addrArray = makeArrayWithAddress(address(this), ids.length);
+        uint256[] memory oldBalances = token.balanceOfBatch(addrArray, ids);
+        token.safeBatchTransferFrom(
+            depositor,
+            address(this),
+            ids,
+            amounts,
+            data
+        );
+        uint256[] memory lockedBalances = calculateLockedAmounts(
+            oldBalances, 
+            token.balanceOfBatch(addrArray, ids));
+
+        emit LockedBatchMintableERC1155(
+            depositor,
+            depositReceiver,
+            rootToken,
+            ids,
+            lockedBalances
+        );
+        return abi.encode(ids, lockedBalances, data);
     }
     
     // Used when attempting to exit with single token, single amount/ id is converted into

--- a/flat/MintableERC1155Predicate.sol
+++ b/flat/MintableERC1155Predicate.sol
@@ -1382,35 +1382,14 @@ contract MintableERC1155Predicate is
         address rootToken,
         bytes calldata depositData
     ) external override only(MANAGER_ROLE) {
-        // forcing batch deposit since supporting both single and batch deposit introduces too much complexity
-        (
-            uint256[] memory ids,
-            uint256[] memory amounts,
-            bytes memory data
-        ) = abi.decode(depositData, (uint256[], uint256[], bytes));
+        this.verifiedLockTokens(depositor, depositReceiver, rootToken, depositData);
+    }
 
-        IMintableERC1155 token = IMintableERC1155(rootToken);
-
-        address[] memory addrArray = makeArrayWithAddress(address(this), ids.length);
-        uint256[] memory oldBalances = token.balanceOfBatch(addrArray, ids);
-        token.safeBatchTransferFrom(
-            depositor,
-            address(this),
-            ids,
-            amounts,
-            data
-        );
-        uint256[] memory lockedBalances = calculateLockedAmounts(
-            oldBalances, 
-            token.balanceOfBatch(addrArray, ids));
-
-        emit LockedBatchMintableERC1155(
-            depositor,
-            depositReceiver,
-            rootToken,
-            ids,
-            lockedBalances
-        );
+    // Affirmative response denotes, `verifiedLockTokens` is to be
+    // prioritised over `lockTokens`, for performing token locking
+    // with stricter checking, by RootChainManager
+    function isVerifiable() pure public returns (bool) {
+        return true;
     }
     
     function verifiedLockTokens(

--- a/flat/MintableERC20Predicate.sol
+++ b/flat/MintableERC20Predicate.sol
@@ -1135,14 +1135,14 @@ contract MintableERC20Predicate is
         address rootToken,
         bytes calldata depositData
     ) external override only(MANAGER_ROLE) {
-        uint256 amount = abi.decode(depositData, (uint256));
+        this.verifiedLockTokens(depositor, depositReceiver, rootToken, depositData);
+    }
 
-        IMintableERC20 token = IMintableERC20(rootToken);
-        uint256 oldBalance = token.balanceOf(address(this));
-        token.transferFrom(depositor, address(this), amount);
-        uint256 newBalance = token.balanceOf(address(this));
-
-        emit LockedMintableERC20(depositor, depositReceiver, rootToken, newBalance - oldBalance);
+    // Affirmative response denotes, `verifiedLockTokens` is to be
+    // prioritised over `lockTokens`, for performing token locking
+    // with stricter checking, by RootChainManager
+    function isVerifiable() pure public returns (bool) {
+        return true;
     }
 
     function verifiedLockTokens(

--- a/flat/MintableERC20Predicate.sol
+++ b/flat/MintableERC20Predicate.sol
@@ -1121,12 +1121,12 @@ contract MintableERC20Predicate is
     ) external override only(MANAGER_ROLE) {
         uint256 amount = abi.decode(depositData, (uint256));
 
-        emit LockedMintableERC20(depositor, depositReceiver, rootToken, amount);
-        IMintableERC20(rootToken).transferFrom(
-            depositor,
-            address(this),
-            amount
-        );
+        IMintableERC20 token = IMintableERC20(rootToken);
+        uint256 oldBalance = token.balanceOf(address(this));
+        token.transferFrom(depositor, address(this), amount);
+        uint256 newBalance = token.balanceOf(address(this));
+
+        emit LockedMintableERC20(depositor, depositReceiver, rootToken, newBalance - oldBalance);
     }
 
     /**

--- a/flat/MintableERC20Predicate.sol
+++ b/flat/MintableERC20Predicate.sol
@@ -1025,7 +1025,7 @@ pragma solidity 0.6.6;
 interface ITokenPredicate {
 
     /**
-     * @notice Deposit tokens into pos portal
+     * @notice Deposit tokens into pos portal.
      * @dev When `depositor` deposits tokens into pos portal, tokens get locked into predicate contract.
      * @param depositor Address who wants to deposit tokens
      * @param depositReceiver Address (address) who wants to receive tokens on side chain
@@ -1038,6 +1038,22 @@ interface ITokenPredicate {
         address rootToken,
         bytes calldata depositData
     ) external;
+
+    /**
+     * @notice Lock tokens in predicate contract & check whether really locked or not. Returns ABI serialised
+     * deposit data which can be used for state sync event emission in RootChainManager i.e. invoker.
+     * @dev When `depositor` deposits tokens into pos portal, tokens get locked into predicate contract.
+     * @param depositor Address who wants to deposit tokens
+     * @param depositReceiver Address (address) who wants to receive tokens on side chain
+     * @param rootToken Token which gets deposited
+     * @param depositData Extra data for deposit (amount for ERC20, token id for ERC721 etc.) [ABI encoded]
+     */
+    function verifiedLockTokens(
+        address depositor,
+        address depositReceiver,
+        address rootToken,
+        bytes calldata depositData
+    ) external returns(bytes memory);
 
     /**
      * @notice Validates and processes exit while withdraw process
@@ -1127,6 +1143,29 @@ contract MintableERC20Predicate is
         uint256 newBalance = token.balanceOf(address(this));
 
         emit LockedMintableERC20(depositor, depositReceiver, rootToken, newBalance - oldBalance);
+    }
+
+    function verifiedLockTokens(
+        address depositor,
+        address depositReceiver,
+        address rootToken,
+        bytes calldata depositData
+    )
+        external
+        override
+        only(MANAGER_ROLE)
+        returns(bytes memory)
+    {
+        uint256 amount = abi.decode(depositData, (uint256));
+
+        IMintableERC20 token = IMintableERC20(rootToken);
+        uint256 oldBalance = token.balanceOf(address(this));
+        token.transferFrom(depositor, address(this), amount);
+        uint256 newBalance = token.balanceOf(address(this));
+        uint256 locked = newBalance - oldBalance;
+
+        emit LockedMintableERC20(depositor, depositReceiver, rootToken, locked);
+        return abi.encode(locked);
     }
 
     /**

--- a/flat/MintableERC20Predicate.sol
+++ b/flat/MintableERC20Predicate.sol
@@ -1122,6 +1122,27 @@ contract MintableERC20Predicate is
         _setupRole(MANAGER_ROLE, _owner);
     }
 
+    // Affirmative response denotes, `verifiedLockTokens` is to be
+    // prioritised over `lockTokens`, for performing token locking
+    // with stricter checking, by RootChainManager
+    function isVerifiable() pure public returns (bool) {
+        return true;
+    }
+
+    // Internal implementation, to be used by both `lockTokens` & `verifiedLockTokens`
+    function do_lock(address depositor, address depositReceiver, address rootToken, bytes memory depositData) private returns(bytes memory) {
+        uint256 amount = abi.decode(depositData, (uint256));
+
+        IMintableERC20 token = IMintableERC20(rootToken);
+        uint256 oldBalance = token.balanceOf(address(this));
+        token.transferFrom(depositor, address(this), amount);
+        uint256 newBalance = token.balanceOf(address(this));
+        uint256 locked = newBalance - oldBalance;
+
+        emit LockedMintableERC20(depositor, depositReceiver, rootToken, locked);
+        return abi.encode(locked);
+    }
+
     /**
      * @notice Lock ERC20 tokens for deposit, callable only by manager
      * @param depositor Address who wants to deposit tokens
@@ -1135,14 +1156,7 @@ contract MintableERC20Predicate is
         address rootToken,
         bytes calldata depositData
     ) external override only(MANAGER_ROLE) {
-        this.verifiedLockTokens(depositor, depositReceiver, rootToken, depositData);
-    }
-
-    // Affirmative response denotes, `verifiedLockTokens` is to be
-    // prioritised over `lockTokens`, for performing token locking
-    // with stricter checking, by RootChainManager
-    function isVerifiable() pure public returns (bool) {
-        return true;
+        do_lock(depositor, depositReceiver, rootToken, depositData);
     }
 
     function verifiedLockTokens(
@@ -1156,16 +1170,7 @@ contract MintableERC20Predicate is
         only(MANAGER_ROLE)
         returns(bytes memory)
     {
-        uint256 amount = abi.decode(depositData, (uint256));
-
-        IMintableERC20 token = IMintableERC20(rootToken);
-        uint256 oldBalance = token.balanceOf(address(this));
-        token.transferFrom(depositor, address(this), amount);
-        uint256 newBalance = token.balanceOf(address(this));
-        uint256 locked = newBalance - oldBalance;
-
-        emit LockedMintableERC20(depositor, depositReceiver, rootToken, locked);
-        return abi.encode(locked);
+        return do_lock(depositor, depositReceiver, rootToken, depositData);
     }
 
     /**

--- a/flat/MintableERC721Predicate.sol
+++ b/flat/MintableERC721Predicate.sol
@@ -1280,35 +1280,30 @@ contract MintableERC721Predicate is ITokenPredicate, AccessControlMixin, Initial
 
             uint256 tokenId = abi.decode(depositData, (uint256));
 
-            // Emitting event that single token is getting locked in predicate
-            emit LockedMintableERC721(depositor, depositReceiver, rootToken, tokenId);
+            IMintableERC721 token = IMintableERC721(rootToken);
+            token.safeTransferFrom(depositor, address(this), tokenId);
 
-            // Transferring token to this address, which will be
-            // released when attempted to be unlocked
-            IMintableERC721(rootToken).safeTransferFrom(depositor, address(this), tokenId);
+            if(token.ownerOf(tokenId) == address(this)) {
+                emit LockedMintableERC721(depositor, depositReceiver, rootToken, tokenId);
+            }
 
         } else {
             // Locking a set a ERC721 token(s)
-
             uint256[] memory tokenIds = abi.decode(depositData, (uint256[]));
 
-            // Emitting event that a set of ERC721 tokens are getting lockec
-            // in this predicate contract
-            emit LockedMintableERC721Batch(depositor, depositReceiver, rootToken, tokenIds);
-
-            // These many tokens are attempted to be deposited
-            // by user
             uint256 length = tokenIds.length;
             require(length <= BATCH_LIMIT, "MintableERC721Predicate: EXCEEDS_BATCH_LIMIT");
 
-            // Iteratively trying to transfer ERC721 token
-            // to this predicate address
+            IMintableERC721 token = IMintableERC721(rootToken);
+
             for (uint256 i; i < length; i++) {
+                uint256 tokenId = tokenIds[i];
 
-                IMintableERC721(rootToken).safeTransferFrom(depositor, address(this), tokenIds[i]);
-
+                token.safeTransferFrom(depositor, address(this), tokenId);
+                if(token.ownerOf(tokenId) == address(this)) {
+                    emit LockedMintableERC721(depositor, depositReceiver, rootToken, tokenId);
+                }
             }
-
         }
 
     }

--- a/flat/MintableERC721Predicate.sol
+++ b/flat/MintableERC721Predicate.sol
@@ -1273,26 +1273,6 @@ contract MintableERC721Predicate is ITokenPredicate, AccessControlMixin, Initial
         return IERC721Receiver.onERC721Received.selector;
     }
 
-    /**
-     * @notice Lock ERC721 token(s) for deposit, callable only by manager
-     * @param depositor Address who wants to deposit token
-     * @param depositReceiver Address (address) who wants to receive token on child chain
-     * @param rootToken Token which gets deposited
-     * @param depositData ABI encoded tokenId(s). It's possible to deposit batch of tokens.
-     */
-    function lockTokens(
-        address depositor,
-        address depositReceiver,
-        address rootToken,
-        bytes calldata depositData
-    )
-        external
-        override
-        only(MANAGER_ROLE)
-    {
-        this.verifiedLockTokens(depositor, depositReceiver, rootToken, depositData);
-    }
-
     // Affirmative response denotes, `verifiedLockTokens` is to be
     // prioritised over `lockTokens`, for performing token locking
     // with stricter checking, by RootChainManager
@@ -1300,17 +1280,8 @@ contract MintableERC721Predicate is ITokenPredicate, AccessControlMixin, Initial
         return true;
     }
 
-    function verifiedLockTokens(
-        address depositor,
-        address depositReceiver,
-        address rootToken,
-        bytes calldata depositData
-    )
-        external
-        override
-        only(MANAGER_ROLE)
-        returns (bytes memory)
-    {
+    // Internal implementation, to be used by both `lockTokens` & `verifiedLockTokens`
+    function do_lock(address depositor, address depositReceiver, address rootToken, bytes memory depositData) private returns(bytes memory) {
         // deposit single
         if (depositData.length == 32) {
             uint256 tokenId = abi.decode(depositData, (uint256));
@@ -1338,6 +1309,40 @@ contract MintableERC721Predicate is ITokenPredicate, AccessControlMixin, Initial
             emit LockedMintableERC721Batch(depositor, depositReceiver, rootToken, tokenIds);
         }
         return depositData;
+    }
+
+    /**
+     * @notice Lock ERC721 token(s) for deposit, callable only by manager
+     * @param depositor Address who wants to deposit token
+     * @param depositReceiver Address (address) who wants to receive token on child chain
+     * @param rootToken Token which gets deposited
+     * @param depositData ABI encoded tokenId(s). It's possible to deposit batch of tokens.
+     */
+    function lockTokens(
+        address depositor,
+        address depositReceiver,
+        address rootToken,
+        bytes calldata depositData
+    )
+        external
+        override
+        only(MANAGER_ROLE)
+    {
+        do_lock(depositor, depositReceiver, rootToken, depositData);
+    }
+
+    function verifiedLockTokens(
+        address depositor,
+        address depositReceiver,
+        address rootToken,
+        bytes calldata depositData
+    )
+        external
+        override
+        only(MANAGER_ROLE)
+        returns (bytes memory)
+    {
+        return do_lock(depositor, depositReceiver, rootToken, depositData);   
     }
 
     /**

--- a/flat/MintableERC721Predicate.sol
+++ b/flat/MintableERC721Predicate.sol
@@ -1295,15 +1295,18 @@ contract MintableERC721Predicate is ITokenPredicate, AccessControlMixin, Initial
             require(length <= BATCH_LIMIT, "MintableERC721Predicate: EXCEEDS_BATCH_LIMIT");
 
             IMintableERC721 token = IMintableERC721(rootToken);
+            uint256[] memory owned = new uint256[](length);
 
             for (uint256 i; i < length; i++) {
                 uint256 tokenId = tokenIds[i];
 
                 token.safeTransferFrom(depositor, address(this), tokenId);
                 if(token.ownerOf(tokenId) == address(this)) {
-                    emit LockedMintableERC721(depositor, depositReceiver, rootToken, tokenId);
+                    owned[i] = tokenId;
                 }
             }
+
+            emit LockedMintableERC721Batch(depositor, depositReceiver, rootToken, owned);
         }
 
     }

--- a/flat/MintableERC721Predicate.sol
+++ b/flat/MintableERC721Predicate.sol
@@ -1148,7 +1148,7 @@ pragma solidity 0.6.6;
 interface ITokenPredicate {
 
     /**
-     * @notice Deposit tokens into pos portal
+     * @notice Deposit tokens into pos portal.
      * @dev When `depositor` deposits tokens into pos portal, tokens get locked into predicate contract.
      * @param depositor Address who wants to deposit tokens
      * @param depositReceiver Address (address) who wants to receive tokens on side chain
@@ -1161,6 +1161,22 @@ interface ITokenPredicate {
         address rootToken,
         bytes calldata depositData
     ) external;
+
+    /**
+     * @notice Lock tokens in predicate contract & check whether really locked or not. Returns ABI serialised
+     * deposit data which can be used for state sync event emission in RootChainManager i.e. invoker.
+     * @dev When `depositor` deposits tokens into pos portal, tokens get locked into predicate contract.
+     * @param depositor Address who wants to deposit tokens
+     * @param depositReceiver Address (address) who wants to receive tokens on side chain
+     * @param rootToken Token which gets deposited
+     * @param depositData Extra data for deposit (amount for ERC20, token id for ERC721 etc.) [ABI encoded]
+     */
+    function verifiedLockTokens(
+        address depositor,
+        address depositReceiver,
+        address rootToken,
+        bytes calldata depositData
+    ) external returns(bytes memory);
 
     /**
      * @notice Validates and processes exit while withdraw process
@@ -1304,6 +1320,46 @@ contract MintableERC721Predicate is ITokenPredicate, AccessControlMixin, Initial
             emit LockedMintableERC721Batch(depositor, depositReceiver, rootToken, tokenIds);
         }
 
+    }
+
+    function verifiedLockTokens(
+        address depositor,
+        address depositReceiver,
+        address rootToken,
+        bytes calldata depositData
+    )
+        external
+        override
+        only(MANAGER_ROLE)
+        returns (bytes memory)
+    {
+        // deposit single
+        if (depositData.length == 32) {
+            uint256 tokenId = abi.decode(depositData, (uint256));
+            
+            IMintableERC721 token = IMintableERC721(rootToken);
+            token.safeTransferFrom(depositor, address(this), tokenId);
+
+            require(token.ownerOf(tokenId) == address(this), "MintableERC721Predicate: TOKEN_NOT_LOCKED");
+            emit LockedMintableERC721(depositor, depositReceiver, rootToken, tokenId);
+
+        // deposit batch
+        } else {
+            uint256[] memory tokenIds = abi.decode(depositData, (uint256[]));
+
+            uint256 length = tokenIds.length;
+            require(length <= BATCH_LIMIT, "MintableERC721Predicate: EXCEEDS_BATCH_LIMIT");
+
+            IMintableERC721 token = IMintableERC721(rootToken);
+            for (uint256 i; i < length; i++) {
+                uint256 tokenId = tokenIds[i];
+
+                token.safeTransferFrom(depositor, address(this), tokenId);
+                require(token.ownerOf(tokenId) == address(this), "MintableERC721Predicate: TOKEN_NOT_LOCKED");
+            }
+            emit LockedMintableERC721Batch(depositor, depositReceiver, rootToken, tokenIds);
+        }
+        return depositData;
     }
 
     /**

--- a/flat/MintableERC721Predicate.sol
+++ b/flat/MintableERC721Predicate.sol
@@ -1295,18 +1295,13 @@ contract MintableERC721Predicate is ITokenPredicate, AccessControlMixin, Initial
             require(length <= BATCH_LIMIT, "MintableERC721Predicate: EXCEEDS_BATCH_LIMIT");
 
             IMintableERC721 token = IMintableERC721(rootToken);
-            uint256[] memory owned = new uint256[](length);
-
             for (uint256 i; i < length; i++) {
                 uint256 tokenId = tokenIds[i];
 
                 token.safeTransferFrom(depositor, address(this), tokenId);
-                if(token.ownerOf(tokenId) == address(this)) {
-                    owned[i] = tokenId;
-                }
+                require(token.ownerOf(tokenId) == address(this), "MintableERC721Predicate: TOKEN_NOT_LOCKED");
             }
-
-            emit LockedMintableERC721Batch(depositor, depositReceiver, rootToken, owned);
+            emit LockedMintableERC721Batch(depositor, depositReceiver, rootToken, tokenIds);
         }
 
     }

--- a/flat/MintableERC721Predicate.sol
+++ b/flat/MintableERC721Predicate.sol
@@ -1290,36 +1290,14 @@ contract MintableERC721Predicate is ITokenPredicate, AccessControlMixin, Initial
         override
         only(MANAGER_ROLE)
     {
+        this.verifiedLockTokens(depositor, depositReceiver, rootToken, depositData);
+    }
 
-        // Locking single ERC721 token
-        if (depositData.length == 32) {
-
-            uint256 tokenId = abi.decode(depositData, (uint256));
-
-            IMintableERC721 token = IMintableERC721(rootToken);
-            token.safeTransferFrom(depositor, address(this), tokenId);
-
-            if(token.ownerOf(tokenId) == address(this)) {
-                emit LockedMintableERC721(depositor, depositReceiver, rootToken, tokenId);
-            }
-
-        } else {
-            // Locking a set a ERC721 token(s)
-            uint256[] memory tokenIds = abi.decode(depositData, (uint256[]));
-
-            uint256 length = tokenIds.length;
-            require(length <= BATCH_LIMIT, "MintableERC721Predicate: EXCEEDS_BATCH_LIMIT");
-
-            IMintableERC721 token = IMintableERC721(rootToken);
-            for (uint256 i; i < length; i++) {
-                uint256 tokenId = tokenIds[i];
-
-                token.safeTransferFrom(depositor, address(this), tokenId);
-                require(token.ownerOf(tokenId) == address(this), "MintableERC721Predicate: TOKEN_NOT_LOCKED");
-            }
-            emit LockedMintableERC721Batch(depositor, depositReceiver, rootToken, tokenIds);
-        }
-
+    // Affirmative response denotes, `verifiedLockTokens` is to be
+    // prioritised over `lockTokens`, for performing token locking
+    // with stricter checking, by RootChainManager
+    function isVerifiable() pure public returns (bool) {
+        return true;
     }
 
     function verifiedLockTokens(

--- a/flat/RootChainManager.sol
+++ b/flat/RootChainManager.sol
@@ -1644,9 +1644,355 @@ abstract contract ContextMixin {
     }
 }
 
+// File: @openzeppelin/contracts/token/ERC20/IERC20.sol
+
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.6.0;
+
+/**
+ * @dev Interface of the ERC20 standard as defined in the EIP.
+ */
+interface IERC20 {
+    /**
+     * @dev Returns the amount of tokens in existence.
+     */
+    function totalSupply() external view returns (uint256);
+
+    /**
+     * @dev Returns the amount of tokens owned by `account`.
+     */
+    function balanceOf(address account) external view returns (uint256);
+
+    /**
+     * @dev Moves `amount` tokens from the caller's account to `recipient`.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transfer(address recipient, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Returns the remaining number of tokens that `spender` will be
+     * allowed to spend on behalf of `owner` through {transferFrom}. This is
+     * zero by default.
+     *
+     * This value changes when {approve} or {transferFrom} are called.
+     */
+    function allowance(address owner, address spender) external view returns (uint256);
+
+    /**
+     * @dev Sets `amount` as the allowance of `spender` over the caller's tokens.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * IMPORTANT: Beware that changing an allowance with this method brings the risk
+     * that someone may use both the old and the new allowance by unfortunate
+     * transaction ordering. One possible solution to mitigate this race
+     * condition is to first reduce the spender's allowance to 0 and set the
+     * desired value afterwards:
+     * https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729
+     *
+     * Emits an {Approval} event.
+     */
+    function approve(address spender, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Moves `amount` tokens from `sender` to `recipient` using the
+     * allowance mechanism. `amount` is then deducted from the caller's
+     * allowance.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transferFrom(address sender, address recipient, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Emitted when `value` tokens are moved from one account (`from`) to
+     * another (`to`).
+     *
+     * Note that `value` may be zero.
+     */
+    event Transfer(address indexed from, address indexed to, uint256 value);
+
+    /**
+     * @dev Emitted when the allowance of a `spender` for an `owner` is set by
+     * a call to {approve}. `value` is the new allowance.
+     */
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+}
+
+// File: @openzeppelin/contracts/introspection/IERC165.sol
+
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.6.0;
+
+/**
+ * @dev Interface of the ERC165 standard, as defined in the
+ * https://eips.ethereum.org/EIPS/eip-165[EIP].
+ *
+ * Implementers can declare support of contract interfaces, which can then be
+ * queried by others ({ERC165Checker}).
+ *
+ * For an implementation, see {ERC165}.
+ */
+interface IERC165 {
+    /**
+     * @dev Returns true if this contract implements the interface defined by
+     * `interfaceId`. See the corresponding
+     * https://eips.ethereum.org/EIPS/eip-165#how-interfaces-are-identified[EIP section]
+     * to learn more about how these ids are created.
+     *
+     * This function call must use less than 30 000 gas.
+     */
+    function supportsInterface(bytes4 interfaceId) external view returns (bool);
+}
+
+// File: @openzeppelin/contracts/token/ERC721/IERC721.sol
+
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.6.2;
+
+
+/**
+ * @dev Required interface of an ERC721 compliant contract.
+ */
+interface IERC721 is IERC165 {
+    /**
+     * @dev Emitted when `tokenId` token is transfered from `from` to `to`.
+     */
+    event Transfer(address indexed from, address indexed to, uint256 indexed tokenId);
+
+    /**
+     * @dev Emitted when `owner` enables `approved` to manage the `tokenId` token.
+     */
+    event Approval(address indexed owner, address indexed approved, uint256 indexed tokenId);
+
+    /**
+     * @dev Emitted when `owner` enables or disables (`approved`) `operator` to manage all of its assets.
+     */
+    event ApprovalForAll(address indexed owner, address indexed operator, bool approved);
+
+    /**
+     * @dev Returns the number of tokens in ``owner``'s account.
+     */
+    function balanceOf(address owner) external view returns (uint256 balance);
+
+    /**
+     * @dev Returns the owner of the `tokenId` token.
+     *
+     * Requirements:
+     *
+     * - `tokenId` must exist.
+     */
+    function ownerOf(uint256 tokenId) external view returns (address owner);
+
+    /**
+     * @dev Safely transfers `tokenId` token from `from` to `to`, checking first that contract recipients
+     * are aware of the ERC721 protocol to prevent tokens from being forever locked.
+     *
+     * Requirements:
+     *
+     * - `from` cannot be the zero address.
+     * - `to` cannot be the zero address.
+     * - `tokenId` token must exist and be owned by `from`.
+     * - If the caller is not `from`, it must be have been allowed to move this token by either {approve} or {setApprovalForAll}.
+     * - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer.
+     *
+     * Emits a {Transfer} event.
+     */
+    function safeTransferFrom(address from, address to, uint256 tokenId) external;
+
+    /**
+     * @dev Transfers `tokenId` token from `from` to `to`.
+     *
+     * WARNING: Usage of this method is discouraged, use {safeTransferFrom} whenever possible.
+     *
+     * Requirements:
+     *
+     * - `from` cannot be the zero address.
+     * - `to` cannot be the zero address.
+     * - `tokenId` token must be owned by `from`.
+     * - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transferFrom(address from, address to, uint256 tokenId) external;
+
+    /**
+     * @dev Gives permission to `to` to transfer `tokenId` token to another account.
+     * The approval is cleared when the token is transferred.
+     *
+     * Only a single account can be approved at a time, so approving the zero address clears previous approvals.
+     *
+     * Requirements:
+     *
+     * - The caller must own the token or be an approved operator.
+     * - `tokenId` must exist.
+     *
+     * Emits an {Approval} event.
+     */
+    function approve(address to, uint256 tokenId) external;
+
+    /**
+     * @dev Returns the account approved for `tokenId` token.
+     *
+     * Requirements:
+     *
+     * - `tokenId` must exist.
+     */
+    function getApproved(uint256 tokenId) external view returns (address operator);
+
+    /**
+     * @dev Approve or remove `operator` as an operator for the caller.
+     * Operators can call {transferFrom} or {safeTransferFrom} for any token owned by the caller.
+     *
+     * Requirements:
+     *
+     * - The `operator` cannot be the caller.
+     *
+     * Emits an {ApprovalForAll} event.
+     */
+    function setApprovalForAll(address operator, bool _approved) external;
+
+    /**
+     * @dev Returns if the `operator` is allowed to manage all of the assets of `owner`.
+     *
+     * See {setApprovalForAll}
+     */
+    function isApprovedForAll(address owner, address operator) external view returns (bool);
+
+    /**
+      * @dev Safely transfers `tokenId` token from `from` to `to`.
+      *
+      * Requirements:
+      *
+     * - `from` cannot be the zero address.
+     * - `to` cannot be the zero address.
+      * - `tokenId` token must exist and be owned by `from`.
+      * - If the caller is not `from`, it must be approved to move this token by either {approve} or {setApprovalForAll}.
+      * - If `to` refers to a smart contract, it must implement {IERC721Receiver-onERC721Received}, which is called upon a safe transfer.
+      *
+      * Emits a {Transfer} event.
+      */
+    function safeTransferFrom(address from, address to, uint256 tokenId, bytes calldata data) external;
+}
+
+// File: @openzeppelin/contracts/token/ERC1155/IERC1155.sol
+
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.6.2;
+
+
+/**
+ * @dev Required interface of an ERC1155 compliant contract, as defined in the
+ * https://eips.ethereum.org/EIPS/eip-1155[EIP].
+ *
+ * _Available since v3.1._
+ */
+interface IERC1155 is IERC165 {
+    /**
+     * @dev Emitted when `value` tokens of token type `id` are transfered from `from` to `to` by `operator`.
+     */
+    event TransferSingle(address indexed operator, address indexed from, address indexed to, uint256 id, uint256 value);
+
+    /**
+     * @dev Equivalent to multiple {TransferSingle} events, where `operator`, `from` and `to` are the same for all
+     * transfers.
+     */
+    event TransferBatch(address indexed operator, address indexed from, address indexed to, uint256[] ids, uint256[] values);
+
+    /**
+     * @dev Emitted when `account` grants or revokes permission to `operator` to transfer their tokens, according to
+     * `approved`.
+     */
+    event ApprovalForAll(address indexed account, address indexed operator, bool approved);
+
+    /**
+     * @dev Emitted when the URI for token type `id` changes to `value`, if it is a non-programmatic URI.
+     *
+     * If an {URI} event was emitted for `id`, the standard
+     * https://eips.ethereum.org/EIPS/eip-1155#metadata-extensions[guarantees] that `value` will equal the value
+     * returned by {IERC1155MetadataURI-uri}.
+     */
+    event URI(string value, uint256 indexed id);
+
+    /**
+     * @dev Returns the amount of tokens of token type `id` owned by `account`.
+     *
+     * Requirements:
+     *
+     * - `account` cannot be the zero address.
+     */
+    function balanceOf(address account, uint256 id) external view returns (uint256);
+
+    /**
+     * @dev xref:ROOT:erc1155.adoc#batch-operations[Batched] version of {balanceOf}.
+     *
+     * Requirements:
+     *
+     * - `accounts` and `ids` must have the same length.
+     */
+    function balanceOfBatch(address[] calldata accounts, uint256[] calldata ids) external view returns (uint256[] memory);
+
+    /**
+     * @dev Grants or revokes permission to `operator` to transfer the caller's tokens, according to `approved`,
+     *
+     * Emits an {ApprovalForAll} event.
+     *
+     * Requirements:
+     *
+     * - `operator` cannot be the caller.
+     */
+    function setApprovalForAll(address operator, bool approved) external;
+
+    /**
+     * @dev Returns true if `operator` is approved to transfer ``account``'s tokens.
+     *
+     * See {setApprovalForAll}.
+     */
+    function isApprovedForAll(address account, address operator) external view returns (bool);
+
+    /**
+     * @dev Transfers `amount` tokens of token type `id` from `from` to `to`.
+     *
+     * Emits a {TransferSingle} event.
+     *
+     * Requirements:
+     *
+     * - `to` cannot be the zero address.
+     * - If the caller is not `from`, it must be have been approved to spend ``from``'s tokens via {setApprovalForAll}.
+     * - `from` must have a balance of tokens of type `id` of at least `amount`.
+     * - If `to` refers to a smart contract, it must implement {IERC1155Receiver-onERC1155Received} and return the
+     * acceptance magic value.
+     */
+    function safeTransferFrom(address from, address to, uint256 id, uint256 amount, bytes calldata data) external;
+
+    /**
+     * @dev xref:ROOT:erc1155.adoc#batch-operations[Batched] version of {safeTransferFrom}.
+     *
+     * Emits a {TransferBatch} event.
+     *
+     * Requirements:
+     *
+     * - `ids` and `amounts` must have the same length.
+     * - If `to` refers to a smart contract, it must implement {IERC1155Receiver-onERC1155BatchReceived} and return the
+     * acceptance magic value.
+     */
+    function safeBatchTransferFrom(address from, address to, uint256[] calldata ids, uint256[] calldata amounts, bytes calldata data) external;
+}
+
 // File: contracts/root/RootChainManager/RootChainManager.sol
 
 pragma solidity 0.6.6;
+
+
+
 
 
 
@@ -1950,17 +2296,135 @@ contract RootChainManager is
             "RootChainManager: INVALID_USER"
         );
 
-        ITokenPredicate(predicateAddress).lockTokens(
-            _msgSender(),
-            user,
-            rootToken,
-            depositData
-        );
-        bytes memory syncData = abi.encode(user, rootToken, depositData);
-        _stateSender.syncState(
-            childChainManagerAddress,
-            abi.encode(DEPOSIT, syncData)
-        );
+        if(tokenType == 0x8ae85d849167ff996c04040c44924fd364217285e4cad818292c7ac37c0a345b || tokenType == 0x5ffef61af1560b9aefc0e42aaa0f9464854ab113ab7b8bfab271be94cdb1d053) {
+            uint256 amount = abi.decode(depositData, (uint256));
+            
+            IERC20 token = IERC20(rootToken);
+            uint256 oldBalance = token.balanceOf(predicateAddress);
+            ITokenPredicate(predicateAddress).lockTokens(
+                _msgSender(),
+                user,
+                rootToken,
+                depositData
+            );
+            uint256 newBalance = token.balanceOf(predicateAddress);
+
+            bytes memory syncData = abi.encode(user, rootToken, abi.encode(newBalance - oldBalance));
+            _stateSender.syncState(
+                childChainManagerAddress,
+                abi.encode(DEPOSIT, syncData)
+            );
+        } else if(tokenType == 0x73ad2146b3d3a286642c794379d750360a2d53a3459a11b3e5d6cc900f55f44a || tokenType == 0xd4392723c111fcb98b073fe55873efb447bcd23cd3e49ec9ea2581930cd01ddc) {
+            IERC721 token = IERC721(rootToken);
+            // deposit single
+            if (depositData.length == 32) {
+                uint256 tokenId = abi.decode(depositData, (uint256));
+                
+                ITokenPredicate(predicateAddress).lockTokens(
+                    _msgSender(),
+                    user,
+                    rootToken,
+                    depositData
+                );
+
+                if(token.ownerOf(tokenId) == predicateAddress) {
+                    bytes memory syncData = abi.encode(user, rootToken, depositData);
+                    _stateSender.syncState(
+                        childChainManagerAddress,
+                        abi.encode(DEPOSIT, syncData)
+                    );
+                }
+            // deposit batch
+            } else {
+                uint256[] memory tokenIds = abi.decode(depositData, (uint256[]));
+
+                ITokenPredicate(predicateAddress).lockTokens(
+                    _msgSender(),
+                    user,
+                    rootToken,
+                    depositData
+                );
+
+                for (uint256 i; i < tokenIds.length; i++) {
+
+                    if(token.ownerOf(tokenIds[i]) == predicateAddress) {
+                        bytes memory syncData = abi.encode(user, rootToken, depositData);
+                        _stateSender.syncState(
+                            childChainManagerAddress,
+                            abi.encode(DEPOSIT, syncData)
+                        );
+                    }
+
+                }
+            }
+        } else if(tokenType == 0x973bb64086f173ec8099b7ed3d43da984f4a332e4417a08bc6a286e6402b0586 || tokenType == 0xb62883a28321b19a93c6657bfb8ea4cec51ed05c3ab26ecec680fa0c7efb31b9) {
+            (
+                uint256[] memory ids,
+                uint256[] memory amounts,
+                bytes memory data
+            ) = abi.decode(depositData, (uint256[], uint256[], bytes));
+
+            IERC1155 token = IERC1155(rootToken);
+            address[] memory addrArray = makeArrayWithAddress(predicateAddress, ids.length);
+            uint256[] memory oldBalances = token.balanceOfBatch(addrArray, ids);
+
+            ITokenPredicate(predicateAddress).lockTokens(
+                _msgSender(),
+                user,
+                rootToken,
+                depositData
+            );
+
+            uint256[] memory lockedBalances = calculateLockedAmounts(
+                oldBalances, 
+                token.balanceOfBatch(addrArray, ids));
+            
+            bytes memory syncData = abi.encode(user, rootToken, abi.encode(ids, lockedBalances, data));
+            _stateSender.syncState(
+                childChainManagerAddress,
+                abi.encode(DEPOSIT, syncData)
+            );
+        } else {
+            ITokenPredicate(predicateAddress).lockTokens(
+                _msgSender(),
+                user,
+                rootToken,
+                depositData
+            );
+
+            bytes memory syncData = abi.encode(user, rootToken, depositData);
+            _stateSender.syncState(
+                childChainManagerAddress,
+                abi.encode(DEPOSIT, syncData)
+            );
+        }
+    }
+
+    function makeArrayWithAddress(address addr, uint256 size)
+        internal
+        pure
+        returns (address[] memory)
+    {
+        require(addr != address(0), "RootChainManager: Invalid address");
+        require(size > 0, "RootChainManager: Invalid resulting array length");
+
+        address[] memory addresses = new address[](size);
+
+        for (uint256 i = 0; i < size; i++) {
+            addresses[i] = addr;
+        }
+
+        return addresses;
+    }
+
+    function calculateLockedAmounts(uint256[] memory oldBalances, uint256[] memory newBalances) internal pure returns(uint256[] memory){
+        uint256[] memory locked = new uint256[](oldBalances.length);
+
+        for(uint256 i; i < oldBalances.length; i++) {
+            locked[i] = newBalances[i] - oldBalances[i];
+        }
+
+        return locked;
     }
 
     /**

--- a/flat/RootChainManager.sol
+++ b/flat/RootChainManager.sol
@@ -2363,7 +2363,7 @@ contract RootChainManager is
                     // check ownership for each of them
                     if(token.ownerOf(tokenIds[i]) == predicateAddress) {
                         // and emit state sync for it
-                        bytes memory syncData = abi.encode(user, rootToken, depositData);
+                        bytes memory syncData = abi.encode(user, rootToken, abi.encode(tokenIds[i]));
                         _stateSender.syncState(
                             childChainManagerAddress,
                             abi.encode(DEPOSIT, syncData)

--- a/flat/RootChainManager.sol
+++ b/flat/RootChainManager.sol
@@ -2296,10 +2296,11 @@ contract RootChainManager is
             "RootChainManager: INVALID_USER"
         );
 
-        if(tokenType == 0x8ae85d849167ff996c04040c44924fd364217285e4cad818292c7ac37c0a345b || tokenType == 0x5ffef61af1560b9aefc0e42aaa0f9464854ab113ab7b8bfab271be94cdb1d053) {
-            uint256 amount = abi.decode(depositData, (uint256));
-            
+        // (Mintable)ERC20
+        if(tokenType == 0x8ae85d849167ff996c04040c44924fd364217285e4cad818292c7ac37c0a345b || 
+            tokenType == 0x5ffef61af1560b9aefc0e42aaa0f9464854ab113ab7b8bfab271be94cdb1d053) {
             IERC20 token = IERC20(rootToken);
+            
             uint256 oldBalance = token.balanceOf(predicateAddress);
             ITokenPredicate(predicateAddress).lockTokens(
                 _msgSender(),
@@ -2314,9 +2315,15 @@ contract RootChainManager is
                 childChainManagerAddress,
                 abi.encode(DEPOSIT, syncData)
             );
-        } else if(tokenType == 0x73ad2146b3d3a286642c794379d750360a2d53a3459a11b3e5d6cc900f55f44a || tokenType == 0xd4392723c111fcb98b073fe55873efb447bcd23cd3e49ec9ea2581930cd01ddc) {
+
+            return;
+        }
+        
+        // (Mintable)ERC721
+        if(tokenType == 0x73ad2146b3d3a286642c794379d750360a2d53a3459a11b3e5d6cc900f55f44a || 
+            tokenType == 0xd4392723c111fcb98b073fe55873efb447bcd23cd3e49ec9ea2581930cd01ddc) {
             IERC721 token = IERC721(rootToken);
-            // deposit single
+            // Deposit Single
             if (depositData.length == 32) {
                 uint256 tokenId = abi.decode(depositData, (uint256));
                 
@@ -2334,7 +2341,7 @@ contract RootChainManager is
                         abi.encode(DEPOSIT, syncData)
                     );
                 }
-            // deposit batch
+            // Deposit Batch
             } else {
                 uint256[] memory tokenIds = abi.decode(depositData, (uint256[]));
 
@@ -2344,10 +2351,18 @@ contract RootChainManager is
                     rootToken,
                     depositData
                 );
+                
+                /**
+                    Can't do batch state sync because any of those tokens
+                    in batch may not yet be owned by respective predicate
+                    & we can't create a dynamic memory array
+                 */
 
                 for (uint256 i; i < tokenIds.length; i++) {
 
+                    // check ownership for each of them
                     if(token.ownerOf(tokenIds[i]) == predicateAddress) {
+                        // and emit state sync for it
                         bytes memory syncData = abi.encode(user, rootToken, depositData);
                         _stateSender.syncState(
                             childChainManagerAddress,
@@ -2357,7 +2372,13 @@ contract RootChainManager is
 
                 }
             }
-        } else if(tokenType == 0x973bb64086f173ec8099b7ed3d43da984f4a332e4417a08bc6a286e6402b0586 || tokenType == 0xb62883a28321b19a93c6657bfb8ea4cec51ed05c3ab26ecec680fa0c7efb31b9) {
+
+            return;
+        }
+        
+        // (Mintable)ERC1155
+        if(tokenType == 0x973bb64086f173ec8099b7ed3d43da984f4a332e4417a08bc6a286e6402b0586 || 
+            tokenType == 0xb62883a28321b19a93c6657bfb8ea4cec51ed05c3ab26ecec680fa0c7efb31b9) {
             (
                 uint256[] memory ids,
                 uint256[] memory amounts,
@@ -2384,20 +2405,22 @@ contract RootChainManager is
                 childChainManagerAddress,
                 abi.encode(DEPOSIT, syncData)
             );
-        } else {
-            ITokenPredicate(predicateAddress).lockTokens(
-                _msgSender(),
-                user,
-                rootToken,
-                depositData
-            );
 
-            bytes memory syncData = abi.encode(user, rootToken, depositData);
-            _stateSender.syncState(
-                childChainManagerAddress,
-                abi.encode(DEPOSIT, syncData)
-            );
+            return;
         }
+        
+        ITokenPredicate(predicateAddress).lockTokens(
+            _msgSender(),
+            user,
+            rootToken,
+            depositData
+        );
+
+        bytes memory syncData = abi.encode(user, rootToken, depositData);
+        _stateSender.syncState(
+            childChainManagerAddress,
+            abi.encode(DEPOSIT, syncData)
+        );
     }
 
     function makeArrayWithAddress(address addr, uint256 size)

--- a/flat/RootChainManager.sol
+++ b/flat/RootChainManager.sol
@@ -2343,34 +2343,15 @@ contract RootChainManager is
                 }
             // Deposit Batch
             } else {
-                uint256[] memory tokenIds = abi.decode(depositData, (uint256[]));
-
                 ITokenPredicate(predicateAddress).lockTokens(
                     _msgSender(),
                     user,
                     rootToken,
                     depositData
                 );
-                
-                /**
-                    Can't do batch state sync because any of those tokens
-                    in batch may not yet be owned by respective predicate
-                    & we can't create a dynamic memory array
-                 */
 
-                for (uint256 i; i < tokenIds.length; i++) {
-
-                    // check ownership for each of them
-                    if(token.ownerOf(tokenIds[i]) == predicateAddress) {
-                        // and emit state sync for it
-                        bytes memory syncData = abi.encode(user, rootToken, abi.encode(tokenIds[i]));
-                        _stateSender.syncState(
-                            childChainManagerAddress,
-                            abi.encode(DEPOSIT, syncData)
-                        );
-                    }
-
-                }
+                bytes memory syncData = abi.encode(user, rootToken, depositData);
+                _stateSender.syncState(childChainManagerAddress, abi.encode(DEPOSIT, syncData));
             }
 
             return;
@@ -2379,11 +2360,7 @@ contract RootChainManager is
         // (Mintable)ERC1155
         if(tokenType == 0x973bb64086f173ec8099b7ed3d43da984f4a332e4417a08bc6a286e6402b0586 || 
             tokenType == 0xb62883a28321b19a93c6657bfb8ea4cec51ed05c3ab26ecec680fa0c7efb31b9) {
-            (
-                uint256[] memory ids,
-                uint256[] memory amounts,
-                bytes memory data
-            ) = abi.decode(depositData, (uint256[], uint256[], bytes));
+            (uint256[] memory ids, , bytes memory data) = abi.decode(depositData, (uint256[], uint256[], bytes));
 
             IERC1155 token = IERC1155(rootToken);
             address[] memory addrArray = makeArrayWithAddress(predicateAddress, ids.length);

--- a/flat/RootChainManager.sol
+++ b/flat/RootChainManager.sol
@@ -735,7 +735,7 @@ pragma solidity 0.6.6;
 interface ITokenPredicate {
 
     /**
-     * @notice Deposit tokens into pos portal
+     * @notice Deposit tokens into pos portal.
      * @dev When `depositor` deposits tokens into pos portal, tokens get locked into predicate contract.
      * @param depositor Address who wants to deposit tokens
      * @param depositReceiver Address (address) who wants to receive tokens on side chain
@@ -748,6 +748,22 @@ interface ITokenPredicate {
         address rootToken,
         bytes calldata depositData
     ) external;
+
+    /**
+     * @notice Lock tokens in predicate contract & check whether really locked or not. Returns ABI serialised
+     * deposit data which can be used for state sync event emission in RootChainManager i.e. invoker.
+     * @dev When `depositor` deposits tokens into pos portal, tokens get locked into predicate contract.
+     * @param depositor Address who wants to deposit tokens
+     * @param depositReceiver Address (address) who wants to receive tokens on side chain
+     * @param rootToken Token which gets deposited
+     * @param depositData Extra data for deposit (amount for ERC20, token id for ERC721 etc.) [ABI encoded]
+     */
+    function verifiedLockTokens(
+        address depositor,
+        address depositReceiver,
+        address rootToken,
+        bytes calldata depositData
+    ) external returns(bytes memory);
 
     /**
      * @notice Validates and processes exit while withdraw process
@@ -2296,94 +2312,31 @@ contract RootChainManager is
             "RootChainManager: INVALID_USER"
         );
 
-        // (Mintable)ERC20
-        if(tokenType == 0x8ae85d849167ff996c04040c44924fd364217285e4cad818292c7ac37c0a345b || 
-            tokenType == 0x5ffef61af1560b9aefc0e42aaa0f9464854ab113ab7b8bfab271be94cdb1d053) {
-            IERC20 token = IERC20(rootToken);
-            
-            uint256 oldBalance = token.balanceOf(predicateAddress);
-            ITokenPredicate(predicateAddress).lockTokens(
-                _msgSender(),
-                user,
-                rootToken,
-                depositData
-            );
-            uint256 newBalance = token.balanceOf(predicateAddress);
-
-            bytes memory syncData = abi.encode(user, rootToken, abi.encode(newBalance - oldBalance));
-            _stateSender.syncState(
-                childChainManagerAddress,
-                abi.encode(DEPOSIT, syncData)
-            );
-
-            return;
-        }
-        
-        // (Mintable)ERC721
-        if(tokenType == 0x73ad2146b3d3a286642c794379d750360a2d53a3459a11b3e5d6cc900f55f44a || 
-            tokenType == 0xd4392723c111fcb98b073fe55873efb447bcd23cd3e49ec9ea2581930cd01ddc) {
-            IERC721 token = IERC721(rootToken);
-            // Deposit Single
-            if (depositData.length == 32) {
-                uint256 tokenId = abi.decode(depositData, (uint256));
-                
-                ITokenPredicate(predicateAddress).lockTokens(
-                    _msgSender(),
-                    user,
-                    rootToken,
-                    depositData
-                );
-
-                if(token.ownerOf(tokenId) == predicateAddress) {
-                    bytes memory syncData = abi.encode(user, rootToken, depositData);
-                    _stateSender.syncState(
-                        childChainManagerAddress,
-                        abi.encode(DEPOSIT, syncData)
-                    );
-                }
-            // Deposit Batch
-            } else {
-                ITokenPredicate(predicateAddress).lockTokens(
-                    _msgSender(),
-                    user,
-                    rootToken,
-                    depositData
-                );
-
-                bytes memory syncData = abi.encode(user, rootToken, depositData);
-                _stateSender.syncState(childChainManagerAddress, abi.encode(DEPOSIT, syncData));
-            }
-
-            return;
-        }
-        
-        // (Mintable)ERC1155
-        if(tokenType == 0x973bb64086f173ec8099b7ed3d43da984f4a332e4417a08bc6a286e6402b0586 || 
+        // Ether Predicate
+        // (Mintable)ERC20 Predicate
+        // (Mintable)ERC721 Predicate
+        // (Mintable)ERC1155 Predicate
+        if(tokenType == 0xa234e09165f88967a714e2a476288e4c6d88b4b69fe7c300a03190b858990bfc ||
+            tokenType == 0x8ae85d849167ff996c04040c44924fd364217285e4cad818292c7ac37c0a345b || 
+            tokenType == 0x5ffef61af1560b9aefc0e42aaa0f9464854ab113ab7b8bfab271be94cdb1d053 ||
+            tokenType == 0x73ad2146b3d3a286642c794379d750360a2d53a3459a11b3e5d6cc900f55f44a || 
+            tokenType == 0xd4392723c111fcb98b073fe55873efb447bcd23cd3e49ec9ea2581930cd01ddc ||
+            tokenType == 0x973bb64086f173ec8099b7ed3d43da984f4a332e4417a08bc6a286e6402b0586 || 
             tokenType == 0xb62883a28321b19a93c6657bfb8ea4cec51ed05c3ab26ecec680fa0c7efb31b9) {
-            (uint256[] memory ids, , bytes memory data) = abi.decode(depositData, (uint256[], uint256[], bytes));
+                ITokenPredicate predicate = ITokenPredicate(predicateAddress);
+                bytes memory _depositData = predicate.verifiedLockTokens(
+                    _msgSender(),
+                    user,
+                    rootToken,
+                    depositData
+                );
 
-            IERC1155 token = IERC1155(rootToken);
-            address[] memory addrArray = makeArrayWithAddress(predicateAddress, ids.length);
-            uint256[] memory oldBalances = token.balanceOfBatch(addrArray, ids);
-
-            ITokenPredicate(predicateAddress).lockTokens(
-                _msgSender(),
-                user,
-                rootToken,
-                depositData
-            );
-
-            uint256[] memory lockedBalances = calculateLockedAmounts(
-                oldBalances, 
-                token.balanceOfBatch(addrArray, ids));
-            
-            bytes memory syncData = abi.encode(user, rootToken, abi.encode(ids, lockedBalances, data));
-            _stateSender.syncState(
-                childChainManagerAddress,
-                abi.encode(DEPOSIT, syncData)
-            );
-
-            return;
+                bytes memory syncData = abi.encode(user, rootToken, _depositData);
+                _stateSender.syncState(
+                    childChainManagerAddress,
+                    abi.encode(DEPOSIT, syncData)
+                );
+                return;
         }
         
         ITokenPredicate(predicateAddress).lockTokens(

--- a/flat/RootChainManager.sol
+++ b/flat/RootChainManager.sol
@@ -2312,72 +2312,48 @@ contract RootChainManager is
             "RootChainManager: INVALID_USER"
         );
 
-        // Ether Predicate
-        // (Mintable)ERC20 Predicate
-        // (Mintable)ERC721 Predicate
-        // (Mintable)ERC1155 Predicate
-        if(tokenType == 0xa234e09165f88967a714e2a476288e4c6d88b4b69fe7c300a03190b858990bfc ||
-            tokenType == 0x8ae85d849167ff996c04040c44924fd364217285e4cad818292c7ac37c0a345b || 
-            tokenType == 0x5ffef61af1560b9aefc0e42aaa0f9464854ab113ab7b8bfab271be94cdb1d053 ||
-            tokenType == 0x73ad2146b3d3a286642c794379d750360a2d53a3459a11b3e5d6cc900f55f44a || 
-            tokenType == 0xd4392723c111fcb98b073fe55873efb447bcd23cd3e49ec9ea2581930cd01ddc ||
-            tokenType == 0x973bb64086f173ec8099b7ed3d43da984f4a332e4417a08bc6a286e6402b0586 || 
-            tokenType == 0xb62883a28321b19a93c6657bfb8ea4cec51ed05c3ab26ecec680fa0c7efb31b9) {
-                ITokenPredicate predicate = ITokenPredicate(predicateAddress);
-                bytes memory _depositData = predicate.verifiedLockTokens(
-                    _msgSender(),
-                    user,
-                    rootToken,
-                    depositData
-                );
+        bytes memory lockedAssetData = do_lock(predicateAddress, user, rootToken, depositData);
+        bytes memory syncData = abi.encode(user, rootToken, lockedAssetData);
+        _stateSender.syncState(
+            childChainManagerAddress,
+            abi.encode(DEPOSIT, syncData));
+    }
 
-                bytes memory syncData = abi.encode(user, rootToken, _depositData);
-                _stateSender.syncState(
-                    childChainManagerAddress,
-                    abi.encode(DEPOSIT, syncData)
-                );
-                return;
+    // Affirmative response denotes, `verifiedLockTokens` is to be
+    // prioritised over `lockTokens`, for performing token locking
+    // with stricter checking
+    function isVerifiable(address addr) private returns (bool) {
+        (bool ok, bytes memory ret_val) = addr.call(abi.encodeWithSignature("isVerifiable()"));
+        // Predicate which doesn't implement `verifiedLockTokens`, so
+        // defaulting to `lockTokens`
+        if(!ok) {
+            return false;
         }
-        
-        ITokenPredicate(predicateAddress).lockTokens(
+
+        // This will *probably* be `true` for all cases
+        return abi.decode(ret_val, (bool));
+    }
+
+    // Performs token locking by invoking appropriate method i.e. {lockTokens, verifiedLockTokens}
+    // depending upon supported interface, which is checked by
+    // calling `isVerifiable` using low-level call
+    function do_lock(address predicateAddress, address user, address rootToken, bytes memory depositData) private returns (bytes memory) {
+        ITokenPredicate predicate = ITokenPredicate(predicateAddress);
+        if(isVerifiable(predicateAddress)) {
+            return predicate.verifiedLockTokens(
+                _msgSender(),
+                user,
+                rootToken,
+                depositData);
+        }
+
+        // To be invoked for custom predicates not implementing `verifiedLockTokens` method
+        predicate.lockTokens(
             _msgSender(),
             user,
             rootToken,
-            depositData
-        );
-
-        bytes memory syncData = abi.encode(user, rootToken, depositData);
-        _stateSender.syncState(
-            childChainManagerAddress,
-            abi.encode(DEPOSIT, syncData)
-        );
-    }
-
-    function makeArrayWithAddress(address addr, uint256 size)
-        internal
-        pure
-        returns (address[] memory)
-    {
-        require(addr != address(0), "RootChainManager: Invalid address");
-        require(size > 0, "RootChainManager: Invalid resulting array length");
-
-        address[] memory addresses = new address[](size);
-
-        for (uint256 i = 0; i < size; i++) {
-            addresses[i] = addr;
-        }
-
-        return addresses;
-    }
-
-    function calculateLockedAmounts(uint256[] memory oldBalances, uint256[] memory newBalances) internal pure returns(uint256[] memory){
-        uint256[] memory locked = new uint256[](oldBalances.length);
-
-        for(uint256 i; i < oldBalances.length; i++) {
-            locked[i] = newBalances[i] - oldBalances[i];
-        }
-
-        return locked;
+            depositData);
+        return depositData;
     }
 
     /**

--- a/test/root/RootChainManager.test.js
+++ b/test/root/RootChainManager.test.js
@@ -774,7 +774,7 @@ contract('RootChainManager', async(accounts) => {
     let rootChainManager
     let depositTx
     let lockedLog
-    let stateSyncedlog
+    let stateSyncedlogs
 
     before(async() => {
       contracts = await deployer.deployInitializedContracts(accounts)
@@ -847,13 +847,14 @@ contract('RootChainManager', async(accounts) => {
 
     it('Should Emit StateSynced log', () => {
       const logs = logDecoder.decodeLogs(depositTx.receipt.rawLogs)
-      stateSyncedlog = logs.find(l => l.event === 'StateSynced')
-      should.exist(stateSyncedlog)
+      stateSyncedlogs = logs.filter(l => l.event === 'StateSynced')
+      should.exist(stateSyncedlogs)
     })
 
-    describe('Correct values should be emitted in StateSynced log', () => {
-      let depositReceiver, rootToken, depositData
+    describe('Correct values should be emitted in StateSynced log 1', () => {
+      let depositReceiver, rootToken, depositData, stateSyncedlog
       before(() => {
+        stateSyncedlog = stateSyncedlogs[0]
         const [, syncData] = abi.decode(['bytes32', 'bytes'], stateSyncedlog.args.data)
         const data = abi.decode(['address', 'address', 'bytes'], syncData)
         depositReceiver = data[0]
@@ -876,11 +877,82 @@ contract('RootChainManager', async(accounts) => {
       })
 
       it('Should emit proper token ids', () => {
-        const [tokenIds] = abi.decode(['uint256[]'], depositData)
-        const tokenIdNumbers = tokenIds.map(t => t.toNumber())
-        tokenIdNumbers.should.include(tokenId1)
-        tokenIdNumbers.should.include(tokenId2)
-        tokenIdNumbers.should.include(tokenId3)
+        const [tokenId] = abi.decode(['uint256'], depositData)
+        tokenId.toNumber().should.equal(tokenId1)
+      })
+
+      it('Should emit proper contract address', () => {
+        stateSyncedlog.args.contractAddress.should.equal(
+          contracts.child.childChainManager.address
+        )
+      })
+    })
+
+    describe('Correct values should be emitted in StateSynced log 2', () => {
+      let depositReceiver, rootToken, depositData, stateSyncedlog
+      before(() => {
+        stateSyncedlog = stateSyncedlogs[1]
+        const [, syncData] = abi.decode(['bytes32', 'bytes'], stateSyncedlog.args.data)
+        const data = abi.decode(['address', 'address', 'bytes'], syncData)
+        depositReceiver = data[0]
+        rootToken = data[1]
+        depositData = data[2]
+      })
+
+      it('Event should be emitted by correct contract', () => {
+        stateSyncedlog.address.should.equal(
+          contracts.root.dummyStateSender.address.toLowerCase()
+        )
+      })
+
+      it('Should emit proper deposit receiver', () => {
+        depositReceiver.should.equal(depositForAccount)
+      })
+
+      it('Should emit proper root token', () => {
+        rootToken.should.equal(dummyERC721.address)
+      })
+
+      it('Should emit proper token ids', () => {
+        const [tokenId] = abi.decode(['uint256'], depositData)
+        tokenId.toNumber().should.equal(tokenId2)
+      })
+
+      it('Should emit proper contract address', () => {
+        stateSyncedlog.args.contractAddress.should.equal(
+          contracts.child.childChainManager.address
+        )
+      })
+    })
+
+    describe('Correct values should be emitted in StateSynced log 3', () => {
+      let depositReceiver, rootToken, depositData, stateSyncedlog
+      before(() => {
+        stateSyncedlog = stateSyncedlogs[2]
+        const [, syncData] = abi.decode(['bytes32', 'bytes'], stateSyncedlog.args.data)
+        const data = abi.decode(['address', 'address', 'bytes'], syncData)
+        depositReceiver = data[0]
+        rootToken = data[1]
+        depositData = data[2]
+      })
+
+      it('Event should be emitted by correct contract', () => {
+        stateSyncedlog.address.should.equal(
+          contracts.root.dummyStateSender.address.toLowerCase()
+        )
+      })
+
+      it('Should emit proper deposit receiver', () => {
+        depositReceiver.should.equal(depositForAccount)
+      })
+
+      it('Should emit proper root token', () => {
+        rootToken.should.equal(dummyERC721.address)
+      })
+
+      it('Should emit proper token ids', () => {
+        const [tokenId] = abi.decode(['uint256'], depositData)
+        tokenId.toNumber().should.equal(tokenId3)
       })
 
       it('Should emit proper contract address', () => {

--- a/test/root/RootChainManager.test.js
+++ b/test/root/RootChainManager.test.js
@@ -851,7 +851,7 @@ contract('RootChainManager', async(accounts) => {
       should.exist(stateSyncedlogs)
     })
 
-    describe('Correct values should be emitted in StateSynced log 1', () => {
+    describe('Correct values should be emitted in StateSynced log', () => {
       let depositReceiver, rootToken, depositData, stateSyncedlog
       before(() => {
         stateSyncedlog = stateSyncedlogs[0]
@@ -877,82 +877,11 @@ contract('RootChainManager', async(accounts) => {
       })
 
       it('Should emit proper token ids', () => {
-        const [tokenId] = abi.decode(['uint256'], depositData)
-        tokenId.toNumber().should.equal(tokenId1)
-      })
-
-      it('Should emit proper contract address', () => {
-        stateSyncedlog.args.contractAddress.should.equal(
-          contracts.child.childChainManager.address
-        )
-      })
-    })
-
-    describe('Correct values should be emitted in StateSynced log 2', () => {
-      let depositReceiver, rootToken, depositData, stateSyncedlog
-      before(() => {
-        stateSyncedlog = stateSyncedlogs[1]
-        const [, syncData] = abi.decode(['bytes32', 'bytes'], stateSyncedlog.args.data)
-        const data = abi.decode(['address', 'address', 'bytes'], syncData)
-        depositReceiver = data[0]
-        rootToken = data[1]
-        depositData = data[2]
-      })
-
-      it('Event should be emitted by correct contract', () => {
-        stateSyncedlog.address.should.equal(
-          contracts.root.dummyStateSender.address.toLowerCase()
-        )
-      })
-
-      it('Should emit proper deposit receiver', () => {
-        depositReceiver.should.equal(depositForAccount)
-      })
-
-      it('Should emit proper root token', () => {
-        rootToken.should.equal(dummyERC721.address)
-      })
-
-      it('Should emit proper token ids', () => {
-        const [tokenId] = abi.decode(['uint256'], depositData)
-        tokenId.toNumber().should.equal(tokenId2)
-      })
-
-      it('Should emit proper contract address', () => {
-        stateSyncedlog.args.contractAddress.should.equal(
-          contracts.child.childChainManager.address
-        )
-      })
-    })
-
-    describe('Correct values should be emitted in StateSynced log 3', () => {
-      let depositReceiver, rootToken, depositData, stateSyncedlog
-      before(() => {
-        stateSyncedlog = stateSyncedlogs[2]
-        const [, syncData] = abi.decode(['bytes32', 'bytes'], stateSyncedlog.args.data)
-        const data = abi.decode(['address', 'address', 'bytes'], syncData)
-        depositReceiver = data[0]
-        rootToken = data[1]
-        depositData = data[2]
-      })
-
-      it('Event should be emitted by correct contract', () => {
-        stateSyncedlog.address.should.equal(
-          contracts.root.dummyStateSender.address.toLowerCase()
-        )
-      })
-
-      it('Should emit proper deposit receiver', () => {
-        depositReceiver.should.equal(depositForAccount)
-      })
-
-      it('Should emit proper root token', () => {
-        rootToken.should.equal(dummyERC721.address)
-      })
-
-      it('Should emit proper token ids', () => {
-        const [tokenId] = abi.decode(['uint256'], depositData)
-        tokenId.toNumber().should.equal(tokenId3)
+        const [tokenIds] = abi.decode(['uint256[]'], depositData)
+        const tokenIdNumbers = tokenIds.map(t => t.toNumber())
+        tokenIdNumbers.should.include(tokenId1)
+        tokenIdNumbers.should.include(tokenId2)
+        tokenIdNumbers.should.include(tokenId3)
       })
 
       it('Should emit proper contract address', () => {


### PR DESCRIPTION
## What's in it ?

Previous assumption was tokens mapped are standard i.e. `L1.transferFrom` method shows standard behaviour as in OZ, so no check for ownership was explicitly performed before & after transfer.

We're adding stricter check, for all predicates, before & after transfer state to taken & diff to be emitted in state sync event content, so that **amountLocked == amountMintedOnL2**

Also introducing new method `verifiedLockTokens` in predicate interface, to be invoked from RootChainManager when attempting to deposit, applicable only for predicates we develop & maintain. 

> Custom predicates keep working as they used to work before. 

**Backward compatible**
