### PR TITLE
Remove exit payload length check

### DIFF
--- a/contracts/root/RootChainManager/RootChainManager.sol
+++ b/contracts/root/RootChainManager/RootChainManager.sol
@@ -340,10 +340,8 @@ contract RootChainManager is
      *  9 - receiptLogIndex - Log Index to read from the receipt
      */
     function exit(bytes calldata inputData) external override {
-        require(inputData.length == 10, "RootChainManager: BAD_PAYLOAD");
-
         ExitPayloadReader.ExitPayload memory payload = inputData.toExitPayload();
-        
+
         bytes memory branchMaskBytes = payload.getBranchMaskAsBytes();
         // checking if exit has already been processed
         // unique exit is identified using hash of (blockNumber, branchMask, receiptLogIndex)

--- a/contracts/tunnel/BaseRootTunnel.sol
+++ b/contracts/tunnel/BaseRootTunnel.sol
@@ -92,9 +92,7 @@ abstract contract BaseRootTunnel is AccessControlMixin {
         stateSender.syncState(childTunnel, message);
     }
 
-    function _validateAndExtractMessage(bytes memory inputData) internal returns (bytes memory) {
-        require(inputData.length == 10, "RootTunnel: BAD_PAYLOAD");
-        
+    function _validateAndExtractMessage(bytes memory inputData) internal returns (bytes memory) {    
         ExitPayloadReader.ExitPayload memory payload = inputData.toExitPayload();
         
         bytes memory branchMaskBytes = payload.getBranchMaskAsBytes();

--- a/flat/RootChainManager.sol
+++ b/flat/RootChainManager.sol
@@ -2247,10 +2247,8 @@ contract RootChainManager is
      *  9 - receiptLogIndex - Log Index to read from the receipt
      */
     function exit(bytes calldata inputData) external override {
-        require(inputData.length == 10, "RootChainManager: BAD_PAYLOAD");
-
         ExitPayloadReader.ExitPayload memory payload = inputData.toExitPayload();
-        
+
         bytes memory branchMaskBytes = payload.getBranchMaskAsBytes();
         // checking if exit has already been processed
         // unique exit is identified using hash of (blockNumber, branchMask, receiptLogIndex)


### PR DESCRIPTION
## Why ?

Sometime ago I added check for decoded exit payload length ( `assert length == 10` ), in PR #85. After that we merged PR #89, which added an wrapper around proof reader library. During merge, proof length check was misplaced, added before decoding, resulting into failing exit payload length check with `BAD_PAYLOAD`.

I'm removing this length check, it doesn't cause any major problem because anyway if some one submits proof of wrong length, if will be failing during decoding. 
