### PR TITLE
Fix exit logic in ChainExit Predicate

### DIFF
--- a/contracts/root/TokenPredicates/ChainExitERC1155Predicate.sol
+++ b/contracts/root/TokenPredicates/ChainExitERC1155Predicate.sol
@@ -157,7 +157,7 @@ contract ChainExitERC1155Predicate is
                 needMintStep = true;
             }
 
-            if(balances[i] > 0) {
+            if (balances[i] > 0) {
                 toBeTransferred[i] = needMintStepInner ? balances[i] : exitAmounts[i];
                 needTransferStep = true;
             }
@@ -199,7 +199,7 @@ contract ChainExitERC1155Predicate is
             uint256[] memory balances = token.balanceOfBatch(makeArrayWithAddress(address(this), ids.length), ids);
             (uint256[] memory toBeMinted, uint256[] memory toBeTransferred, bool needMintStep, bool needTransferStep) = calculateAmountToMintAndTransfer(balances, amounts);
 
-            if(needMintStep) {
+            if (needMintStep) {
                 token.mintBatch(
                     withdrawer,
                     ids,
@@ -208,7 +208,7 @@ contract ChainExitERC1155Predicate is
                 );
             }
 
-            if(needTransferStep) {
+            if (needTransferStep) {
                 token.safeBatchTransferFrom(
                     address(this),
                     withdrawer,

--- a/contracts/root/TokenPredicates/ChainExitERC1155Predicate.sol
+++ b/contracts/root/TokenPredicates/ChainExitERC1155Predicate.sol
@@ -131,15 +131,14 @@ contract ChainExitERC1155Predicate is
     }
 
     /**
-     * @notice Calculates amount of tokens to be minted, by subtracting available
-     * token balances from amount of tokens to be exited
+     * @notice Calculates amount of tokens to be minted and/or transferred
      * @param balances Token balances this contract holds for some ordered token ids
      * @param exitAmounts Amount of tokens being exited
      */
-    function calculateAmountsToBeMinted(
+    function calculateAmountToMintAndTransfer(
         uint256[] memory balances,
         uint256[] memory exitAmounts
-    ) internal pure returns (uint256[] memory, bool, bool) {
+    ) internal pure returns (uint256[] memory, uint256[] memory, bool, bool) {
         uint256 count = balances.length;
         require(
             count == exitAmounts.length,
@@ -147,21 +146,26 @@ contract ChainExitERC1155Predicate is
         );
 
         uint256[] memory toBeMinted = new uint256[](count);
+        uint256[] memory toBeTransferred = new uint256[](count);
         bool needMintStep;
         bool needTransferStep;
 
         for (uint256 i = 0; i < count; i++) {
-            if (balances[i] < exitAmounts[i]) {
+            bool needMintStepInner = balances[i] < exitAmounts[i];
+            if (needMintStepInner) {
                 toBeMinted[i] = exitAmounts[i] - balances[i];
                 needMintStep = true;
             }
 
-            if(balances[i] != 0) {
+            if(balances[i] > 0) {
+                toBeTransferred[i] = needMintStepInner ? balances[i] : exitAmounts[i];
                 needTransferStep = true;
             }
+
+            assert(toBeTransferred[i] + toBeMinted[i] == exitAmounts[i]);
         }
 
-        return (toBeMinted, needMintStep, needTransferStep);
+        return (toBeMinted, toBeTransferred, needMintStep, needTransferStep);
     }
 
     /**
@@ -193,7 +197,7 @@ contract ChainExitERC1155Predicate is
             IMintableERC1155 token = IMintableERC1155(rootToken);
 
             uint256[] memory balances = token.balanceOfBatch(makeArrayWithAddress(address(this), ids.length), ids);
-            (uint256[] memory toBeMinted, bool needMintStep, bool needTransferStep) = calculateAmountsToBeMinted(balances, amounts);
+            (uint256[] memory toBeMinted, uint256[] memory toBeTransferred, bool needMintStep, bool needTransferStep) = calculateAmountToMintAndTransfer(balances, amounts);
 
             if(needMintStep) {
                 token.mintBatch(
@@ -209,7 +213,7 @@ contract ChainExitERC1155Predicate is
                     address(this),
                     withdrawer,
                     ids,
-                    balances,
+                    toBeTransferred,
                     data // passing data when transferring unlocked tokens to withdrawer
                 );
             }

--- a/flat/ChainExitERC1155Predicate.sol
+++ b/flat/ChainExitERC1155Predicate.sol
@@ -1526,7 +1526,7 @@ contract ChainExitERC1155Predicate is
                 needMintStep = true;
             }
 
-            if(balances[i] > 0) {
+            if (balances[i] > 0) {
                 toBeTransferred[i] = needMintStepInner ? balances[i] : exitAmounts[i];
                 needTransferStep = true;
             }
@@ -1568,7 +1568,7 @@ contract ChainExitERC1155Predicate is
             uint256[] memory balances = token.balanceOfBatch(makeArrayWithAddress(address(this), ids.length), ids);
             (uint256[] memory toBeMinted, uint256[] memory toBeTransferred, bool needMintStep, bool needTransferStep) = calculateAmountToMintAndTransfer(balances, amounts);
 
-            if(needMintStep) {
+            if (needMintStep) {
                 token.mintBatch(
                     withdrawer,
                     ids,
@@ -1577,7 +1577,7 @@ contract ChainExitERC1155Predicate is
                 );
             }
 
-            if(needTransferStep) {
+            if (needTransferStep) {
                 token.safeBatchTransferFrom(
                     address(this),
                     withdrawer,


### PR DESCRIPTION
## Why ?

I received report that exit function of ChainExit predicate is not behaving as it's supposed to be. When locked token > exited token, whole locked supply is transferred to withdrawer. 

You may want to check, burn tx: https://mumbai.polygonscan.com/tx/0x901bd75d8b8143039808492ecc902aaf7287c5dc766ca2e11d8a3dd2441514bb

and exit tx: https://goerli.etherscan.io/tx/0x8c117bf08df53ca4b56da117ae4b4c2b1dfafcfbb9f69c07ae18cc1d77c3638d#eventlog

This happened due to https://github.com/maticnetwork/pos-portal/blob/88dbf0a88fd68fa11f7a3b9d36629930f6b93a05/contracts/root/TokenPredicates/ChainExitERC1155Predicate.sol#L212 which wrongly used `balances` array in transfer step.

This PR solves this problem, instead using different arrays for keeping track of `to be minted` & `to be transferred` amounts.
