### PR TITLE
Remove SafeMath from NativeMetaTransaction

### DIFF
--- a/contracts/common/NativeMetaTransaction.sol
+++ b/contracts/common/NativeMetaTransaction.sol
@@ -1,10 +1,9 @@
 pragma solidity 0.6.6;
 
-import {SafeMath} from "@openzeppelin/contracts/math/SafeMath.sol";
 import {EIP712Base} from "./EIP712Base.sol";
 
 contract NativeMetaTransaction is EIP712Base {
-    using SafeMath for uint256;
+
     bytes32 private constant META_TRANSACTION_TYPEHASH = keccak256(
         bytes(
             "MetaTransaction(uint256 nonce,address from,bytes functionSignature)"


### PR DESCRIPTION
There is nothing using SafeMath in this contract, and SafeMath has moved in the latest OpenZeppeling versions, making it impossible to import NativeMetaTransaction from @maticnetwork/pos-portal to use in custom BridgableTokens