### PR TITLE
Update `MintableERC1155Predicate`

### DIFF
--- a/contracts/root/TokenPredicates/MintableERC1155Predicate.sol
+++ b/contracts/root/TokenPredicates/MintableERC1155Predicate.sol
@@ -177,34 +177,37 @@ contract MintableERC1155Predicate is
     function calculateAmountsToBeMinted(
         uint256[] memory tokenBalances,
         uint256[] memory amountsToBeExited
-    ) internal pure returns (uint256[] memory, bool, bool) {
+    ) internal pure returns (uint256[] memory, uint256[] memory, bool) {
         require(
             tokenBalances.length == amountsToBeExited.length,
             "MintableERC1155Predicate: Array length mismatch found"
         );
 
+        // all cells zero initialized
         uint256[] memory toBeMintedAmounts = new uint256[](
             tokenBalances.length
         );
+        // all cells zero initialized
+        uint256[] memory toBeTransferredAmounts = new uint256[](
+            tokenBalances.length
+        );
         bool needMintStep;
-        bool needTransferStep;
 
-        // Iteratively calculating amounts of token to be minted
+        // Iteratively calculating amounts of token to be minted/ transferred
         //
         // Please note, in some cases it can be 0, but that will not
-        // be a problem, due to implementation of mint logic for ERC1155
+        // be a problem, due to implementation of mint/ transfer logic for ERC1155
         for (uint256 i = 0; i < tokenBalances.length; i++) {
             if (tokenBalances[i] < amountsToBeExited[i]) {
                 toBeMintedAmounts[i] = amountsToBeExited[i] - tokenBalances[i];
+                toBeTransferredAmounts[i] = tokenBalances[i];
                 needMintStep = true;
-            }
-
-            if(tokenBalances[i] != 0) {
-                needTransferStep = true;
+            } else {
+                toBeTransferredAmounts[i] = amountsToBeExited[i];
             }
         }
 
-        return (toBeMintedAmounts, needMintStep, needTransferStep);
+        return (toBeMintedAmounts, toBeTransferredAmounts, needMintStep);
     }
 
     /**
@@ -242,14 +245,20 @@ contract MintableERC1155Predicate is
             uint256 balance = token.balanceOf(address(this), id);
             if (balance < amount) {
                 token.mint(withdrawer, id, amount - balance, bytes(""));
-            }
 
-            if(balance != 0) {
                 token.safeTransferFrom(
                     address(this),
                     withdrawer,
                     id,
                     balance,
+                    bytes("")
+                );
+            } else {
+                token.safeTransferFrom(
+                    address(this),
+                    withdrawer,
+                    id,
+                    amount,
                     bytes("")
                 );
             }
@@ -265,7 +274,7 @@ contract MintableERC1155Predicate is
             IMintableERC1155 token = IMintableERC1155(rootToken);
 
             uint256[] memory balances = token.balanceOfBatch(makeArrayWithAddress(address(this), ids.length), ids);
-            (uint256[] memory toBeMinted, bool needMintStep, bool needTransferStep) = calculateAmountsToBeMinted(balances, amounts);
+            (uint256[] memory toBeMinted, uint256[] memory toBeTransferred, bool needMintStep) = calculateAmountsToBeMinted(balances, amounts);
 
             if(needMintStep) {
                 token.mintBatch(
@@ -276,15 +285,13 @@ contract MintableERC1155Predicate is
                 );
             }
 
-            if(needTransferStep) {
-                token.safeBatchTransferFrom(
-                    address(this),
-                    withdrawer,
-                    ids,
-                    balances,
-                    bytes("")
-                );
-            }
+            token.safeBatchTransferFrom(
+                address(this),
+                withdrawer,
+                ids,
+                toBeTransferred,
+                bytes("")
+            );
 
             emit ExitedBatchMintableERC1155(withdrawer, rootToken, ids, amounts);
         } else {


### PR DESCRIPTION
This PR fixes MintableERC1155Predicate while extending *how/ when this predicate can be used assumption*; along with that I've updated accompanying test cases for `exitTokens` function. 

---

I've updated dependency such that test cases can be easily run on local development machine.

1. In one window start local RPC node 

```bash
ganache-cli --hardfork istanbul --mnemonic 'clock radar mass judge dismiss just intact mind resemble fringe diary casino' --gasLimit 8000000 --gasPrice 0 --port 9545 --networkId 53227
```

2. In other window start running test cases

```bash
npm run test
```
