### PR TITLE
Removed extra import

### DIFF
--- a/contracts/tunnel/BaseRootTunnel.sol
+++ b/contracts/tunnel/BaseRootTunnel.sol
@@ -8,7 +8,6 @@ import {IStateSender} from "../root/StateSender/IStateSender.sol";
 import {RLPReader} from "../lib/RLPReader.sol";
 import {MerklePatriciaProof} from "../lib/MerklePatriciaProof.sol";
 import {ICheckpointManager} from "../root/ICheckpointManager.sol";
-import {RLPReader} from "../lib/RLPReader.sol";
 import {Merkle} from "../lib/Merkle.sol";
 import {ExitPayloadReader} from "../lib/ExitPayloadReader.sol";
 


### PR DESCRIPTION
`import {RLPReader} from "../lib/RLPReader.sol";` appeared twice in the imports in `tunnel/BaseRootTunnel.sol`

this should not affect the bytecode