### PR TITLE
add disclaimer for spoofing attack

### DIFF
--- a/contracts/common/ContextMixin.sol
+++ b/contracts/common/ContextMixin.sol
@@ -1,5 +1,13 @@
 pragma solidity 0.6.6;
 
+/**
+ * @notice DISCLAIMER:
+ * Do not use NativeMetaTransaction and ContextMixin together with OpenZeppelin's "multicall"
+ * nor any other form of self delegatecall!
+ * Risk of address spoofing attacks.
+ * Read more: https://blog.openzeppelin.com/arbitrary-address-spoofing-vulnerability-erc2771context-multicall-public-disclosure
+ */
+
 abstract contract ContextMixin {
     function msgSender()
         internal

--- a/contracts/common/NativeMetaTransaction.sol
+++ b/contracts/common/NativeMetaTransaction.sol
@@ -1,5 +1,13 @@
 pragma solidity 0.6.6;
 
+/**
+ * @notice DISCLAIMER:
+ * Do not use NativeMetaTransaction and ContextMixin together with OpenZeppelin's "multicall"
+ * nor any other form of self delegatecall!
+ * Risk of address spoofing attacks.
+ * Read more: https://blog.openzeppelin.com/arbitrary-address-spoofing-vulnerability-erc2771context-multicall-public-disclosure
+ */
+
 import {SafeMath} from "@openzeppelin/contracts/math/SafeMath.sol";
 import {EIP712Base} from "./EIP712Base.sol";
 


### PR DESCRIPTION
Add a disclaimer in `NativeMetaTransaction` and `ContextMixin` 
to alert developers to the fact of a potential vulnerability
when used in conjunction with OpenZeppelin's `multicall` or other forms of self `delegatecall`.