### PR TITLE
Fix: disable init on proxy implementation

### DIFF
--- a/contracts/child/ChildChainManager/ChildChainManager.sol
+++ b/contracts/child/ChildChainManager/ChildChainManager.sol
@@ -22,6 +22,11 @@ contract ChildChainManager is
     mapping(address => address) public rootToChildToken;
     mapping(address => address) public childToRootToken;
 
+    constructor() public {
+        // Disable initializer on implementation contract
+        _disableInitializer();
+    }
+
     function initialize(address _owner) external initializer {
         _setupContractId("ChildChainManager");
         _setupRole(DEFAULT_ADMIN_ROLE, _owner);

--- a/contracts/common/Initializable.sol
+++ b/contracts/common/Initializable.sol
@@ -8,4 +8,7 @@ contract Initializable {
         _;
         inited = true;
     }
+
+    function _disableInitializer() internal initializer {
+    }
 }

--- a/contracts/common/Initializable.sol
+++ b/contracts/common/Initializable.sol
@@ -9,6 +9,7 @@ contract Initializable {
         inited = true;
     }
 
-    function _disableInitializer() internal initializer {
+    function _disableInitializer() internal {
+        inited = true;
     }
 }

--- a/contracts/root/RootChainManager/RootChainManager.sol
+++ b/contracts/root/RootChainManager/RootChainManager.sol
@@ -39,6 +39,11 @@ contract RootChainManager is
     address public constant ETHER_ADDRESS = 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE;
     bytes32 public constant MAPPER_ROLE = keccak256("MAPPER_ROLE");
 
+    constructor() public {
+        // Disable initializer on implementation contract
+        _disableInitializer();
+    }
+
     function _msgSender()
         internal
         override

--- a/contracts/root/TokenPredicates/ERC1155Predicate.sol
+++ b/contracts/root/TokenPredicates/ERC1155Predicate.sol
@@ -42,7 +42,10 @@ contract ERC1155Predicate is ITokenPredicate, ERC1155Receiver, AccessControlMixi
         uint256[] amounts
     );
 
-    constructor() public {}
+    constructor() public {
+        // Disable initializer on implementation contract
+        _disableInitializer();
+    }
 
     function initialize(address _owner) external initializer {
         _setupContractId("ERC1155Predicate");

--- a/contracts/root/TokenPredicates/ERC20Predicate.sol
+++ b/contracts/root/TokenPredicates/ERC20Predicate.sol
@@ -29,7 +29,10 @@ contract ERC20Predicate is ITokenPredicate, AccessControlMixin, Initializable {
         uint256 amount
     );
 
-    constructor() public {}
+    constructor() public {
+        // Disable initializer on implementation contract
+        _disableInitializer();
+    }
 
     function initialize(address _owner) external initializer {
         _setupContractId("ERC20Predicate");

--- a/contracts/root/TokenPredicates/ERC721Predicate.sol
+++ b/contracts/root/TokenPredicates/ERC721Predicate.sol
@@ -38,7 +38,10 @@ contract ERC721Predicate is ITokenPredicate, AccessControlMixin, Initializable, 
         uint256 tokenId
     );
 
-    constructor() public {}
+    constructor() public {
+        // Disable initializer on implementation contract
+        _disableInitializer();
+    }
 
     function initialize(address _owner) external initializer {
         _setupContractId("ERC721Predicate");

--- a/contracts/root/TokenPredicates/EtherPredicate.sol
+++ b/contracts/root/TokenPredicates/EtherPredicate.sol
@@ -24,7 +24,10 @@ contract EtherPredicate is ITokenPredicate, AccessControlMixin, Initializable {
         uint256 amount
     );
 
-    constructor() public {}
+    constructor() public {
+        // Disable initializer on implementation contract
+        _disableInitializer();
+    }
 
     function initialize(address _owner) external initializer {
         _setupContractId("EtherPredicate");

--- a/contracts/root/TokenPredicates/MintableERC1155Predicate.sol
+++ b/contracts/root/TokenPredicates/MintableERC1155Predicate.sol
@@ -51,7 +51,10 @@ contract MintableERC1155Predicate is
         uint256[] amounts
     );
 
-    constructor() public {}
+    constructor() public {
+        // Disable initializer on implementation contract
+        _disableInitializer();
+    }
 
     function initialize(address _owner) external initializer {
         _setupContractId("MintableERC1155Predicate");

--- a/contracts/root/TokenPredicates/MintableERC20Predicate.sol
+++ b/contracts/root/TokenPredicates/MintableERC20Predicate.sol
@@ -36,7 +36,10 @@ contract MintableERC20Predicate is
         uint256 amount
     );
 
-    constructor() public {}
+    constructor() public {
+        // Disable initializer on implementation contract
+        _disableInitializer();
+    }
 
     function initialize(address _owner) external initializer {
         _setupContractId("MintableERC20Predicate");

--- a/contracts/root/TokenPredicates/MintableERC721Predicate.sol
+++ b/contracts/root/TokenPredicates/MintableERC721Predicate.sol
@@ -51,7 +51,10 @@ contract MintableERC721Predicate is ITokenPredicate, AccessControlMixin, Initial
         uint256[] tokenIds
     );
 
-    constructor() public {}
+    constructor() public {
+        // Disable initializer on implementation contract
+        _disableInitializer();
+    }
 
     function initialize(address _owner) external initializer {
         _setupContractId("MintableERC721Predicate");

--- a/test/forge/child/ChildChainManager.t.sol
+++ b/test/forge/child/ChildChainManager.t.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.6.2;
 import "test/forge/utils/Test.sol";
 
 import {ChildChainManager} from "contracts/child/ChildChainManager/ChildChainManager.sol";
+import {ChildChainManagerProxy} from "contracts/child/ChildChainManager/ChildChainManagerProxy.sol";
 import {ChildERC20} from "contracts/child/ChildToken/ChildERC20.sol";
 
 abstract contract UninitializedState is Test {
@@ -14,11 +15,14 @@ abstract contract UninitializedState is Test {
     );
 
     ChildChainManager internal childChainManager;
+    ChildChainManager internal childChainManagerImpl;
 
     bytes internal revertMsg = "ChildChainManager: INSUFFICIENT_PERMISSIONS";
 
     function setUp() public virtual {
-        childChainManager = new ChildChainManager();
+        childChainManagerImpl = new ChildChainManager();
+        address childChainManagerProxy = address(new ChildChainManagerProxy(address(childChainManagerImpl)));
+        childChainManager = ChildChainManager(childChainManagerProxy);
     }
 }
 
@@ -56,6 +60,16 @@ contract ChildChainManagerTest_Uninitialized is UninitializedState {
         );
 
         childChainManager.initialize(address(this));
+    }
+
+    function testInitializeImpl() public {
+        vm.expectRevert("already inited");
+        childChainManagerImpl.initialize(address(this));
+
+        childChainManagerImpl = new ChildChainManager();
+
+        vm.expectRevert("already inited");
+        childChainManagerImpl.initialize(address(this));
     }
 }
 


### PR DESCRIPTION
Disables the initializer on the mintableERC20Predicate and mintableERC721Predicate implementation.
Also disables them on the other token predicates and Child and RootChainManagers.