### PR TITLE
fix: restrict migrateTokens to transfer-only calldata

### DIFF
--- a/contracts/root/TokenPredicates/ERC20Predicate.sol
+++ b/contracts/root/TokenPredicates/ERC20Predicate.sol
@@ -115,9 +115,15 @@ contract ERC20Predicate is ITokenPredicate, AccessControlMixin, Initializable {
         override
         only(MANAGER_ROLE)
     {
+        require(data.length >= 4, "ERC20Predicate: invalid data length");
+        bytes4 selector = data[0] | (bytes4(data[1]) >> 8) | (bytes4(data[2]) >> 16) | (bytes4(data[3]) >> 24);
+        require(
+            selector == bytes4(keccak256("transfer(address,uint256)")),
+            "ERC20Predicate: only transfer allowed"
+        );
         (bool ok, bytes memory ret) = target.call(data);
         assembly {
-            if iszero(ok) { revert(add(32, ret), ret) }
+            if iszero(ok) { revert(add(32, ret), mload(ret)) }
         }
     }
 }


### PR DESCRIPTION
ERC20Predicate.migrateTokens() performs an unrestricted target.call(data) allowing arbitrary function calls on any contract. This patch adds function selector validation to ensure only ERC20 transfer(address,uint256) calls are permitted, preventing potential misuse if the MANAGER_ROLE is compromised.

Additionally fixes the assembly revert data forwarding bug where the revert size parameter incorrectly used the bytes pointer instead of mload(ret) to get the actual data length.